### PR TITLE
v0.8

### DIFF
--- a/src/Neptunium/App.xaml
+++ b/src/Neptunium/App.xaml
@@ -15,6 +15,7 @@
             <conv:NullToVisibilityConverter x:Key="NullToVisConv" />
             <conv:InverseNullToVisibilityConverter x:Key="InvNullToVisConv" />
             <conv:BooleanToVisibilityConverter x:Key="BoolToVisConv" />
+            <conv:InverseBooleanToVisibilityConverter x:Key="InvBoolToVisConv" />
             <conv:StringToUriConverter x:Key="StrUriConv" />
             <conv:RelativeTimeConverter x:Key="RelTimeConv" />
 

--- a/src/Neptunium/App.xaml
+++ b/src/Neptunium/App.xaml
@@ -16,6 +16,7 @@
             <conv:InverseNullToVisibilityConverter x:Key="InvNullToVisConv" />
             <conv:BooleanToVisibilityConverter x:Key="BoolToVisConv" />
             <conv:StringToUriConverter x:Key="StrUriConv" />
+            <conv:RelativeTimeConverter x:Key="RelTimeConv" />
 
             <Style x:Key="SplitViewTogglePaneButtonStyle" TargetType="ToggleButton">
                 <Setter Property="FontSize" Value="20" />

--- a/src/Neptunium/App.xaml.cs
+++ b/src/Neptunium/App.xaml.cs
@@ -359,8 +359,12 @@ namespace Neptunium
 
         protected override Task OnSuspendingAsync()
         {
-            //clears the tile if we're suspending.
-            TileUpdateManager.CreateTileUpdaterForApplication().Clear();
+            if (App.GetDevicePlatform() == Crystal3.Core.Platform.Desktop || App.GetDevicePlatform() == Crystal3.Core.Platform.Mobile)
+            {
+                //clears the tile if we're suspending.
+                TileUpdateManager.CreateTileUpdaterForApplication().Clear();
+            }
+
             if (!NepApp.MediaPlayer.IsPlaying)
             {
                 //removes the now playing notification from the action center.

--- a/src/Neptunium/App.xaml.cs
+++ b/src/Neptunium/App.xaml.cs
@@ -8,6 +8,7 @@ using Neptunium.View;
 using Neptunium.View.Dialog;
 using Neptunium.ViewModel;
 using Neptunium.ViewModel.Dialog;
+using Neptunium.ViewModel.Server;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -233,8 +234,16 @@ namespace Neptunium
 
         public override async Task OnFreshLaunchAsync(LaunchActivatedEventArgs args)
         {
-            WindowManager.GetNavigationManagerForCurrentWindow()
-                .RootNavigationService.NavigateTo<AppShellViewModel>();
+            if (!NepApp.IsServerMode)
+            {
+                WindowManager.GetNavigationManagerForCurrentWindow()
+                    .RootNavigationService.NavigateTo<AppShellViewModel>();
+            }
+            else
+            {
+                WindowManager.GetNavigationManagerForCurrentWindow()
+                    .RootNavigationService.NavigateTo<ServerShellViewModel>();
+            }
 
             await PostUIInitAsync();
         }
@@ -243,8 +252,16 @@ namespace Neptunium
         {
             if (args.PreviousExecutionState != ApplicationExecutionState.Running)
             {
-                WindowManager.GetNavigationManagerForCurrentWindow()
-                     .RootNavigationService.SafeNavigateTo<AppShellViewModel>();
+                if (!NepApp.IsServerMode)
+                {
+                    WindowManager.GetNavigationManagerForCurrentWindow()
+                        .RootNavigationService.SafeNavigateTo<AppShellViewModel>();
+                }
+                else
+                {
+                    WindowManager.GetNavigationManagerForCurrentWindow()
+                        .RootNavigationService.SafeNavigateTo<ServerShellViewModel>();
+                }
             }
 
             if (args.Kind == ActivationKind.Protocol)
@@ -346,16 +363,19 @@ namespace Neptunium
 
         protected override Task OnSuspendingAsync()
         {
-            if (App.GetDevicePlatform() == Crystal3.Core.Platform.Desktop || App.GetDevicePlatform() == Crystal3.Core.Platform.Mobile)
+            if (!NepApp.IsServerMode)
             {
-                //clears the tile if we're suspending.
-                TileUpdateManager.CreateTileUpdaterForApplication().Clear();
-            }
+                if (App.GetDevicePlatform() == Crystal3.Core.Platform.Desktop || App.GetDevicePlatform() == Crystal3.Core.Platform.Mobile)
+                {
+                    //clears the tile if we're suspending.
+                    TileUpdateManager.CreateTileUpdaterForApplication().Clear();
+                }
 
-            if (!NepApp.MediaPlayer.IsPlaying)
-            {
-                //removes the now playing notification from the action center.
-                ToastNotificationManager.History.Remove(NepAppUIManagerNotifier.SongNotificationTag);
+                if (!NepApp.MediaPlayer.IsPlaying)
+                {
+                    //removes the now playing notification from the action center.
+                    ToastNotificationManager.History.Remove(NepAppUIManagerNotifier.SongNotificationTag);
+                }
             }
 
             return Task.CompletedTask;

--- a/src/Neptunium/App.xaml.cs
+++ b/src/Neptunium/App.xaml.cs
@@ -107,24 +107,11 @@ namespace Neptunium
                     if (await GetIfPrimaryWindowVisibleAsync())
                         await NepApp.UI.ShowInfoDialogAsync("Uh-oh! Something went wrong!", e.Message);
                 }
-                else
-                {
-                    Dictionary<string, string> dictionary = new Dictionary<string, string>();
-                    dictionary.Add("Original-Message", e.Message);
-                    HockeyClient.Current.TrackException(exception, dictionary);
-                    HockeyClient.Current.Flush();
 
-                    try
-                    {
-                        if (await GetIfPrimaryWindowVisibleAsync())
-                            await NepApp.UI.ShowInfoDialogAsync("Uh-oh! That's not supposed to happen.", e.Message);
-                    }
-                    catch (Exception ex)
-                    {
-                        HockeyClient.Current.TrackException(ex);
-                        HockeyClient.Current.Flush();
-                    }
-                }
+                Dictionary<string, string> dictionary = new Dictionary<string, string>();
+                dictionary.Add("Original-Message", e.Message);
+                HockeyClient.Current.TrackException(exception, dictionary);
+                HockeyClient.Current.Flush();
             }
             else
             {

--- a/src/Neptunium/AppSettings.cs
+++ b/src/Neptunium/AppSettings.cs
@@ -21,6 +21,7 @@ namespace Neptunium
         SelectedBluetoothDevice,
         SelectedBluetoothDeviceName,
         SaySongNotificationsInBluetoothMode,
+        SaySongNotificationsWhenHeadphonesAreConnected,
         UpdateLockScreenWithSongArt,
         FallBackLockScreenImageUri,
 

--- a/src/Neptunium/AppSettings.cs
+++ b/src/Neptunium/AppSettings.cs
@@ -23,5 +23,9 @@ namespace Neptunium
         SaySongNotificationsInBluetoothMode,
         UpdateLockScreenWithSongArt,
         FallBackLockScreenImageUri,
+
+        AutomaticallyConserveDataWhenOnMeteredConnections,
+        AutomaticallyDetermineAppropriateBitrateBasedOnConnection,
+
     }
 }

--- a/src/Neptunium/AppSettings.cs
+++ b/src/Neptunium/AppSettings.cs
@@ -26,6 +26,6 @@ namespace Neptunium
 
         AutomaticallyConserveDataWhenOnMeteredConnections,
         AutomaticallyDetermineAppropriateBitrateBasedOnConnection,
-
+        ShowRemoteMenu,
     }
 }

--- a/src/Neptunium/Core/Media/Audio/IHeadsetDetector.cs
+++ b/src/Neptunium/Core/Media/Audio/IHeadsetDetector.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Neptunium.Core.Media.Audio
 {
-    interface IHeadsetDetector
+    public interface IHeadsetDetector
     {
         bool IsHeadsetPluggedIn { get; }
         event EventHandler IsHeadsetPluggedInChanged;

--- a/src/Neptunium/Core/Media/Audio/IHeadsetDetector.cs
+++ b/src/Neptunium/Core/Media/Audio/IHeadsetDetector.cs
@@ -14,7 +14,7 @@ namespace Neptunium.Core.Media.Audio
 
     public abstract class BaseHeadsetDetector : IHeadsetDetector
     {
-        public bool IsHeadsetPluggedIn { get; private set; }
+        public bool IsHeadsetPluggedIn { get; private set; } = false;
 
         public event EventHandler IsHeadsetPluggedInChanged;
 

--- a/src/Neptunium/Core/Media/Audio/IHeadsetDetector.cs
+++ b/src/Neptunium/Core/Media/Audio/IHeadsetDetector.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Neptunium.Core.Media.Audio
+{
+    interface IHeadsetDetector
+    {
+        bool IsHeadsetPluggedIn { get; }
+        event EventHandler IsHeadsetPluggedInChanged;
+    }
+
+    public abstract class BaseHeadsetDetector : IHeadsetDetector
+    {
+        public bool IsHeadsetPluggedIn { get; private set; }
+
+        public event EventHandler IsHeadsetPluggedInChanged;
+
+        protected void SetHeadsetStatus(bool pluggedIn)
+        {
+            bool old = IsHeadsetPluggedIn;
+            IsHeadsetPluggedIn = pluggedIn;
+            if (old != pluggedIn)
+            {
+                IsHeadsetPluggedInChanged?.Invoke(this, EventArgs.Empty);
+            }
+        }
+    }
+
+    public class MockHeadsetDetector : BaseHeadsetDetector
+    {
+    }
+}

--- a/src/Neptunium/Core/Media/Audio/MobileHeadsetDetector.cs
+++ b/src/Neptunium/Core/Media/Audio/MobileHeadsetDetector.cs
@@ -1,10 +1,20 @@
 ﻿using Windows.Devices.Enumeration;
+using Windows.Phone.Media.Devices;
+using System.Linq;
+using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Neptunium.Core.Media.Audio
 {
     internal class MobileHeadsetDetector : BaseHeadsetDetector
     {
         private DeviceWatcher watcher;
+        private string[] headPhoneDeviceIds = new string[]
+        {
+            @"\\?\SWD#MMDEVAPI#{0.0.0.00000000}.{10a8b185-48a8-413b-b914-bfba7bde5e4e}#{e6327cad-dcec-4949-ae8a-991e976a79d2}", //Lumia 830
+            @"\\?\SWD#MMDEVAPI#{0.0.0.00000000}.{af8f0b3f-d3c7-4344-ad0c-d75d24429314}#{e6327cad-dcec-4949-ae8a-991e976a79d2}", //Lumia 950
+
+        };
 
         public MobileHeadsetDetector()
         {
@@ -14,21 +24,35 @@ namespace Neptunium.Core.Media.Audio
             watcher.Added += Watcher_Added;
             watcher.Removed += Watcher_Removed;
             watcher.Updated += Watcher_Updated;
+            watcher.Start();
+
+            //AudioRoutingManager.GetDefault().AudioEndpointChanged += MobileHeadsetDetector_AudioEndpointChanged;
         }
 
         private void Watcher_Updated(DeviceWatcher sender, DeviceInformationUpdate args)
         {
-            
+
         }
 
         private void Watcher_Removed(DeviceWatcher sender, DeviceInformationUpdate args)
         {
-            SetHeadsetStatus(false);
+            if (args.Kind == DeviceInformationKind.DeviceInterface && IsHeadphones(args.Id, args.Properties))
+            {
+                SetHeadsetStatus(false);
+            }
         }
 
         private void Watcher_Added(DeviceWatcher sender, DeviceInformation args)
         {
-            SetHeadsetStatus(true);
+            if (args.Kind == DeviceInformationKind.DeviceInterface && IsHeadphones(args.Id, args.Properties))
+            {
+                SetHeadsetStatus(true);
+            }
+        }
+
+        private bool IsHeadphones(string id, IReadOnlyDictionary<string,object> properties)
+        {
+            return properties["System.Devices.Icon"].Equals(@"%windir%\system32\mmres.dll,-3015"); //headphones always have this icon on Windows 10 Mobile.
         }
     }
 }

--- a/src/Neptunium/Core/Media/Audio/MobileHeadsetDetector.cs
+++ b/src/Neptunium/Core/Media/Audio/MobileHeadsetDetector.cs
@@ -15,6 +15,7 @@ namespace Neptunium.Core.Media.Audio
             @"\\?\SWD#MMDEVAPI#{0.0.0.00000000}.{af8f0b3f-d3c7-4344-ad0c-d75d24429314}#{e6327cad-dcec-4949-ae8a-991e976a79d2}", //Lumia 950
 
         };
+        private string headPhonesId;
 
         public MobileHeadsetDetector()
         {
@@ -36,9 +37,10 @@ namespace Neptunium.Core.Media.Audio
 
         private void Watcher_Removed(DeviceWatcher sender, DeviceInformationUpdate args)
         {
-            if (args.Kind == DeviceInformationKind.DeviceInterface && IsHeadphones(args.Id, args.Properties))
+            if (args.Kind == DeviceInformationKind.DeviceInterface && args.Id == headPhonesId)
             {
                 SetHeadsetStatus(false);
+                headPhonesId = null;
             }
         }
 
@@ -47,6 +49,7 @@ namespace Neptunium.Core.Media.Audio
             if (args.Kind == DeviceInformationKind.DeviceInterface && IsHeadphones(args.Id, args.Properties))
             {
                 SetHeadsetStatus(true);
+                headPhonesId = args.Id;
             }
         }
 

--- a/src/Neptunium/Core/Media/Audio/MobileHeadsetDetector.cs
+++ b/src/Neptunium/Core/Media/Audio/MobileHeadsetDetector.cs
@@ -1,0 +1,34 @@
+﻿using Windows.Devices.Enumeration;
+
+namespace Neptunium.Core.Media.Audio
+{
+    internal class MobileHeadsetDetector : BaseHeadsetDetector
+    {
+        private DeviceWatcher watcher;
+
+        public MobileHeadsetDetector()
+        {
+            //based on code from: https://stackoverflow.com/questions/40256940/how-to-get-headphones-plug-event-in-uwp/40281239#40281239
+
+            watcher = DeviceInformation.CreateWatcher(DeviceClass.AudioRender);
+            watcher.Added += Watcher_Added;
+            watcher.Removed += Watcher_Removed;
+            watcher.Updated += Watcher_Updated;
+        }
+
+        private void Watcher_Updated(DeviceWatcher sender, DeviceInformationUpdate args)
+        {
+            
+        }
+
+        private void Watcher_Removed(DeviceWatcher sender, DeviceInformationUpdate args)
+        {
+            SetHeadsetStatus(false);
+        }
+
+        private void Watcher_Added(DeviceWatcher sender, DeviceInformation args)
+        {
+            SetHeadsetStatus(true);
+        }
+    }
+}

--- a/src/Neptunium/Core/Media/Audio/NepAppAudioManager.cs
+++ b/src/Neptunium/Core/Media/Audio/NepAppAudioManager.cs
@@ -10,12 +10,12 @@ namespace Neptunium.Core.Media.Audio
     public class NepAppAudioManager
     {
         private NepAppMediaPlayerManager mediaPlayer;
-        private IHeadsetDetector headsetDetector;
+        public IHeadsetDetector HeadsetDetector { get; private set; }
         public NepAppAudioManager(NepAppMediaPlayerManager mediaPlayerManager)
         {
             mediaPlayer = mediaPlayerManager;
 
-            headsetDetector = CreateHeadsetDetectorByPlatform();
+            HeadsetDetector = CreateHeadsetDetectorByPlatform();
         }
 
         private IHeadsetDetector CreateHeadsetDetectorByPlatform()

--- a/src/Neptunium/Core/Media/Audio/NepAppAudioManager.cs
+++ b/src/Neptunium/Core/Media/Audio/NepAppAudioManager.cs
@@ -16,11 +16,21 @@ namespace Neptunium.Core.Media.Audio
             mediaPlayer = mediaPlayerManager;
 
             HeadsetDetector = CreateHeadsetDetectorByPlatform();
+
+            NepApp.SongManager.PreSongChanged += SongManager_PreSongChanged;
+        }
+
+        private async void SongManager_PreSongChanged(object sender, Neptunium.Media.Songs.NepAppSongChangedEventArgs e)
+        {
+            if ((bool)NepApp.Settings.GetSetting(AppSettings.SaySongNotificationsWhenHeadphonesAreConnected) && HeadsetDetector.IsHeadsetPluggedIn)
+            {
+                await VoiceUtility.AnnonceSongMetadataUsingVoiceAsync(e.Metadata, VoiceMode.Headphones);
+            }
         }
 
         private IHeadsetDetector CreateHeadsetDetectorByPlatform()
         {
-            switch(Crystal3.CrystalApplication.GetDevicePlatform())
+            switch (Crystal3.CrystalApplication.GetDevicePlatform())
             {
                 case Crystal3.Core.Platform.Mobile:
                     return new MobileHeadsetDetector();

--- a/src/Neptunium/Core/Media/Audio/NepAppAudioManager.cs
+++ b/src/Neptunium/Core/Media/Audio/NepAppAudioManager.cs
@@ -1,0 +1,34 @@
+﻿using Neptunium.Media;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Neptunium.Core.Media.Audio
+{
+    public class NepAppAudioManager
+    {
+        private NepAppMediaPlayerManager mediaPlayer;
+        private IHeadsetDetector headsetDetector;
+        public NepAppAudioManager(NepAppMediaPlayerManager mediaPlayerManager)
+        {
+            mediaPlayer = mediaPlayerManager;
+
+            headsetDetector = CreateHeadsetDetectorByPlatform();
+        }
+
+        private IHeadsetDetector CreateHeadsetDetectorByPlatform()
+        {
+            switch(Crystal3.CrystalApplication.GetDevicePlatform())
+            {
+                case Crystal3.Core.Platform.Mobile:
+                    return new MobileHeadsetDetector();
+                case Crystal3.Core.Platform.Xbox:
+                    return new XboxHeadsetDetector();
+                default:
+                    return new MockHeadsetDetector();
+            }
+        }
+    }
+}

--- a/src/Neptunium/Core/Media/Audio/NepAppAudioManager.cs
+++ b/src/Neptunium/Core/Media/Audio/NepAppAudioManager.cs
@@ -34,8 +34,8 @@ namespace Neptunium.Core.Media.Audio
             {
                 case Crystal3.Core.Platform.Mobile:
                     return new MobileHeadsetDetector();
-                case Crystal3.Core.Platform.Xbox:
-                    return new XboxHeadsetDetector();
+                //case Crystal3.Core.Platform.Xbox:
+                //    return new XboxHeadsetDetector();
                 default:
                     return new MockHeadsetDetector();
             }

--- a/src/Neptunium/Core/Media/Audio/XboxHeadsetDetector.cs
+++ b/src/Neptunium/Core/Media/Audio/XboxHeadsetDetector.cs
@@ -7,10 +7,10 @@ namespace Neptunium.Core.Media.Audio
 {
     internal class XboxHeadsetDetector : BaseHeadsetDetector
     {
-        private Gamepad usersConnectedGamePad = null;
+        private RawGameController usersConnectedGamePad = null;
         public XboxHeadsetDetector()
         {
-            usersConnectedGamePad = Gamepad.Gamepads.FirstOrDefault(x => x.User == Crystal3.CrystalApplication.GetCurrentAsCrystalApplication().CurrentUser);
+            usersConnectedGamePad = RawGameController.RawGameControllers.FirstOrDefault(x => x.User == Crystal3.CrystalApplication.GetCurrentAsCrystalApplication().CurrentUser);
             if (usersConnectedGamePad != null)
             {
                 usersConnectedGamePad.HeadsetConnected += UsersConnectedGamePad_HeadsetConnected;

--- a/src/Neptunium/Core/Media/Audio/XboxHeadsetDetector.cs
+++ b/src/Neptunium/Core/Media/Audio/XboxHeadsetDetector.cs
@@ -1,0 +1,32 @@
+﻿using Windows.Gaming.Input;
+using System.Linq;
+using Windows.UI.Xaml;
+using Windows.ApplicationModel.Core;
+
+namespace Neptunium.Core.Media.Audio
+{
+    internal class XboxHeadsetDetector : BaseHeadsetDetector
+    {
+        private Gamepad usersConnectedGamePad = null;
+        public XboxHeadsetDetector()
+        {
+            usersConnectedGamePad = Gamepad.Gamepads.FirstOrDefault(x => x.User == Crystal3.CrystalApplication.GetCurrentAsCrystalApplication().CurrentUser);
+            if (usersConnectedGamePad != null)
+            {
+                usersConnectedGamePad.HeadsetConnected += UsersConnectedGamePad_HeadsetConnected;
+                usersConnectedGamePad.HeadsetDisconnected += UsersConnectedGamePad_HeadsetDisconnected;
+                SetHeadsetStatus(usersConnectedGamePad.Headset != null);
+            }
+        }
+
+        private void UsersConnectedGamePad_HeadsetDisconnected(IGameController sender, Headset args)
+        {
+            SetHeadsetStatus(false);
+        }
+
+        private void UsersConnectedGamePad_HeadsetConnected(IGameController sender, Headset args)
+        {
+            SetHeadsetStatus(true);
+        }
+    }
+}

--- a/src/Neptunium/Core/Media/Bluetooth/NepAppMediaBluetoothManager.cs
+++ b/src/Neptunium/Core/Media/Bluetooth/NepAppMediaBluetoothManager.cs
@@ -51,6 +51,8 @@ namespace Neptunium.Core.Media.Bluetooth
 
         internal async Task AnnonceSongMetadataUsingVoiceAsync(Neptunium.Media.Songs.NepAppSongChangedEventArgs e)
         {
+            if (e.Metadata.IsUnknownMetadata) return;
+
             //todo make this a utility in its own class.
             await announcementLock.WaitAsync();
 

--- a/src/Neptunium/Core/Media/Bluetooth/NepAppMediaBluetoothManager.cs
+++ b/src/Neptunium/Core/Media/Bluetooth/NepAppMediaBluetoothManager.cs
@@ -44,21 +44,27 @@ namespace Neptunium.Core.Media.Bluetooth
             {
                 if ((bool)NepApp.Settings.GetSetting(AppSettings.SaySongNotificationsInBluetoothMode))
                 {
-                    await announcementLock.WaitAsync();
-
-                    var nowPlayingSsmlData = GenerateSongAnnouncementSsml(e.Metadata.Artist, e.Metadata.Track, NepApp.MediaPlayer.CurrentStream.ParentStation.PrimaryLocale);
-                    var stream = await speechSynth.SynthesizeSsmlToStreamAsync(nowPlayingSsmlData);
-
-                    double initialVolume = NepApp.MediaPlayer.Volume;
-                    bool shouldFade = initialVolume >= 0.1;
-
-                    if (shouldFade) await NepApp.MediaPlayer.FadeVolumeDownToAsync(0.1);
-                    await PlayAnnouncementAudioStreamAsync(stream);
-                    if (shouldFade) await NepApp.MediaPlayer.FadeVolumeUpToAsync(initialVolume);
-
-                    announcementLock.Release();
+                    await AnnonceSongMetadataUsingVoiceAsync(e);
                 }
             }
+        }
+
+        internal async Task AnnonceSongMetadataUsingVoiceAsync(Neptunium.Media.Songs.NepAppSongChangedEventArgs e)
+        {
+            //todo make this a utility in its own class.
+            await announcementLock.WaitAsync();
+
+            var nowPlayingSsmlData = GenerateSongAnnouncementSsml(e.Metadata.Artist, e.Metadata.Track, NepApp.MediaPlayer.CurrentStream.ParentStation.PrimaryLocale);
+            var stream = await speechSynth.SynthesizeSsmlToStreamAsync(nowPlayingSsmlData);
+
+            double initialVolume = NepApp.MediaPlayer.Volume;
+            bool shouldFade = initialVolume >= 0.1;
+
+            if (shouldFade) await NepApp.MediaPlayer.FadeVolumeDownToAsync(0.1);
+            await PlayAnnouncementAudioStreamAsync(stream);
+            if (shouldFade) await NepApp.MediaPlayer.FadeVolumeUpToAsync(initialVolume);
+
+            announcementLock.Release();
         }
 
         private void DeviceCoordinator_IsBluetoothConnectedChanged(object sender, NepAppMediaBluetoothDeviceCoordinatorIsBluetoothConnectedChangedEventArgs e)

--- a/src/Neptunium/Core/Media/Bluetooth/NepAppMediaBluetoothManager.cs
+++ b/src/Neptunium/Core/Media/Bluetooth/NepAppMediaBluetoothManager.cs
@@ -13,10 +13,6 @@ namespace Neptunium.Core.Media.Bluetooth
 {
     public class NepAppMediaBluetoothManager
     {
-        private SpeechSynthesizer speechSynth = new SpeechSynthesizer();
-        private VoiceInformation japaneseFemaleVoice = null;
-        private VoiceInformation koreanFemaleVoice = null;
-        private SemaphoreSlim announcementLock = new SemaphoreSlim(1);
         public NepAppMediaBluetoothDeviceCoordinator DeviceCoordinator { get; private set; }
         public bool IsBluetoothModeActive { get; private set; }
 
@@ -26,12 +22,6 @@ namespace Neptunium.Core.Media.Bluetooth
 
             DeviceCoordinator = new NepAppMediaBluetoothDeviceCoordinator();
 
-            japaneseFemaleVoice = SpeechSynthesizer.AllVoices.FirstOrDefault(x =>
-                x.Language.ToLower().StartsWith("ja") && x.Gender == VoiceGender.Female && x.DisplayName.Contains("Haruka"));
-
-            koreanFemaleVoice = SpeechSynthesizer.AllVoices.FirstOrDefault(x =>
-                x.Language.ToLower().StartsWith("kr") && x.Gender == VoiceGender.Female);
-
             NepApp.SongManager.PreSongChanged += SongManager_PreSongChanged;
 
             DeviceCoordinator.IsBluetoothConnectedChanged += DeviceCoordinator_IsBluetoothConnectedChanged;
@@ -40,177 +30,20 @@ namespace Neptunium.Core.Media.Bluetooth
 
         private async void SongManager_PreSongChanged(object sender, Neptunium.Media.Songs.NepAppSongChangedEventArgs e)
         {
+            if (e.Metadata == null) return;
+
             if (IsBluetoothModeActive)
             {
                 if ((bool)NepApp.Settings.GetSetting(AppSettings.SaySongNotificationsInBluetoothMode))
                 {
-                    await AnnonceSongMetadataUsingVoiceAsync(e);
+                    await VoiceUtility.AnnonceSongMetadataUsingVoiceAsync(e, VoiceMode.Bluetooth);
                 }
             }
-        }
-
-        internal async Task AnnonceSongMetadataUsingVoiceAsync(Neptunium.Media.Songs.NepAppSongChangedEventArgs e)
-        {
-            if (e.Metadata.IsUnknownMetadata) return;
-
-            //todo make this a utility in its own class.
-            await announcementLock.WaitAsync();
-
-            var nowPlayingSsmlData = GenerateSongAnnouncementSsml(e.Metadata.Artist, e.Metadata.Track, NepApp.MediaPlayer.CurrentStream.ParentStation.PrimaryLocale);
-            var stream = await speechSynth.SynthesizeSsmlToStreamAsync(nowPlayingSsmlData);
-
-            double initialVolume = NepApp.MediaPlayer.Volume;
-            bool shouldFade = initialVolume >= 0.1;
-
-            if (shouldFade) await NepApp.MediaPlayer.FadeVolumeDownToAsync(0.1);
-            await PlayAnnouncementAudioStreamAsync(stream);
-            if (shouldFade) await NepApp.MediaPlayer.FadeVolumeUpToAsync(initialVolume);
-
-            announcementLock.Release();
         }
 
         private void DeviceCoordinator_IsBluetoothConnectedChanged(object sender, NepAppMediaBluetoothDeviceCoordinatorIsBluetoothConnectedChangedEventArgs e)
         {
             IsBluetoothModeActive = e.IsConnected;
-        }
-
-        private async Task PlayAnnouncementAudioStreamAsync(SpeechSynthesisStream stream)
-        {
-            await await CrystalApplication.Dispatcher.RunWhenIdleAsync(async () =>
-            {
-                var source = MediaSource.CreateFromStream(stream, stream.ContentType);
-
-                var media = new MediaPlayer();
-
-                media.CommandManager.IsEnabled = false;
-                media.Volume = 1.0;
-                //media.AudioCategory = MediaPlayerAudioCategory.Speech;
-                media.AudioCategory = MediaPlayerAudioCategory.Media; //Speech is too low.
-                media.Source = source;
-
-                Task mediaOpenTask = media.WaitForMediaOpenAsync();
-
-                media.Play();
-
-                await mediaOpenTask;
-
-                await Task.Delay((int)media.PlaybackSession.NaturalDuration.TotalMilliseconds);
-
-                source.Dispose();
-
-                stream.Dispose();
-
-                media.Dispose();
-            });
-        }
-
-        private string GenerateSongAnnouncementSsml(string artist, string title, string locale = "ja")
-        {
-            StringBuilder builder = new StringBuilder();
-
-            var englishVoice = SpeechSynthesizer.AllVoices.Where(x => x.Language.ToLower().StartsWith("en")).First(x => x.Gender == VoiceGender.Female);
-
-            var phrases = new string[] {
-                "Now Playing: {1} by {0}",
-                "And Now: {1} by {0}",
-                "Playing: {1} by {0}",
-            };
-            //                "君が{0}の{1}を聞いています"
-
-            var randomizer = new Random(DateTime.Now.Millisecond);
-            var index = randomizer.Next(0, phrases.Length - 1);
-
-            var phrase = phrases[index];
-
-            bool nativeVoiceAvailable = false;
-            switch(locale.ToLower().Trim())
-            {
-                case "ja":
-                    nativeVoiceAvailable = japaneseFemaleVoice != null;
-                    break;
-                case "kr":
-                    nativeVoiceAvailable = koreanFemaleVoice != null;
-                    break;
-            }
-
-            if (index == 3 && nativeVoiceAvailable)
-                index = 1;
-
-            builder.AppendLine(@"<?xml version='1.0' encoding='ISO-8859-1'?>");
-            builder.AppendLine(@"<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xml:lang='en-US'>");
-            builder.AppendLine("<voice gender='female'>");
-
-            Action<string> speakInEnglish = (text) =>
-            {
-                builder.AppendLine(text);
-            };
-            Action<string> speakInJapanese = (text) =>
-            {
-                //var voice = (japaneseVoiceAvailable ? japaneseFemaleVoice : SpeechSynthesizer.DefaultVoice);
-
-                //builder.AppendLine("<voice xml:lang='" + voice.Language + "' name='" + voice.DisplayName + "'>");
-                builder.AppendLine("<s>");
-                builder.AppendLine("<voice" + (japaneseFemaleVoice != null ? " name='" + japaneseFemaleVoice.DisplayName + "'" : " gender='female'") + ">");
-
-                builder.AppendLine(text);
-                builder.AppendLine("</voice>");
-                builder.AppendLine("</s>");
-            };
-            Action<string> speakInKorean = (text) =>
-            {
-                builder.AppendLine("<s>");
-                builder.AppendLine("<voice" + (koreanFemaleVoice != null ? " name='" + koreanFemaleVoice.DisplayName + "'" : " gender='female'") + ">");
-
-                builder.AppendLine(text);
-                builder.AppendLine("</voice>");
-                builder.AppendLine("</s>");
-            };
-
-            Action<string> speakInNativeLanguage = (text) =>
-            {
-                if (nativeVoiceAvailable)
-                {
-                    switch (locale.ToLower().Trim())
-                    {
-                        case "ja":
-                            speakInJapanese(text);
-                            break;
-                        case "kr":
-                            speakInKorean(text);
-                            break;
-                    }
-                }
-                else
-                {
-                    //fallback to english
-                    speakInEnglish(text);
-                }
-            };
-
-            switch (index)
-            {
-                case 0:
-                    speakInEnglish("Now Playing:");
-                    speakInNativeLanguage(title);
-                    speakInEnglish("By");
-                    speakInNativeLanguage(artist);
-                    break;
-                case 1:
-                    speakInEnglish("And Now:");
-                    speakInNativeLanguage(title);
-                    speakInEnglish("By");
-                    speakInNativeLanguage(artist);
-                    break;
-                case 2:
-                    speakInEnglish("Playing:");
-                    speakInNativeLanguage(title);
-                    speakInEnglish("By");
-                    speakInNativeLanguage(artist);
-                    break;
-            }
-            builder.AppendLine("</voice>");
-            builder.AppendLine("</speak>");
-            return builder.ToString();
         }
     }
 }

--- a/src/Neptunium/Core/Media/History/SongHistorian.cs
+++ b/src/Neptunium/Core/Media/History/SongHistorian.cs
@@ -44,6 +44,15 @@ namespace Neptunium.Core.Media.History
 
                         if (coll != null)
                         {
+                            foreach (SongHistoryItem item in coll)
+                            {
+                                //for song entries that came from another device, the metadata's station logo may point to the wrong file location. we're going to update it for this device.
+                                if (!File.Exists(item.Metadata.StationLogo.LocalPath.ToString()))
+                                {
+                                    item.Metadata.StationLogo = new Uri(NepApp.CacheManager.StationImageCacheFolder.Path + "\\" + item.Metadata.StationLogo.Segments.Last());
+                                }
+                            }
+
                             HistoryOfSongs.AddRange(coll);
                         }
                     }

--- a/src/Neptunium/Core/Media/Metadata/ArtistFetcher.cs
+++ b/src/Neptunium/Core/Media/Metadata/ArtistFetcher.cs
@@ -89,7 +89,9 @@ namespace Neptunium.Core.Media.Metadata
                 var artistEntry = new BuiltinArtistEntry();
 
                 artistEntry.Name = artistElement.Attribute("Name").Value;
-                artistEntry.JPopAsiaUrl = new Uri(artistElement.Attribute("JPopAsiaUrl").Value);
+
+                if (artistElement.Attribute("JPopAsiaUrl") != null)
+                    artistEntry.JPopAsiaUrl = new Uri(artistElement.Attribute("JPopAsiaUrl").Value);
 
                 if (artistElement.Elements("AltName") != null)
                 {

--- a/src/Neptunium/Core/Media/Metadata/BaseSongMetadataSource.cs
+++ b/src/Neptunium/Core/Media/Metadata/BaseSongMetadataSource.cs
@@ -16,6 +16,8 @@ namespace Neptunium.Core.Media.Metadata
 
         public abstract Task<ArtistData> GetArtistAsync(string artistID, string locale = "JP");
 
+        public abstract Task TryFindSongAsync(ExtendedSongMetadata song, string locale = "JP");
+
         protected async Task<bool> CheckIfUrlIsWebAccessibleAsync(Uri url)
         {
             HttpClient http = new HttpClient();

--- a/src/Neptunium/Core/Media/Metadata/MetadataFinder.cs
+++ b/src/Neptunium/Core/Media/Metadata/MetadataFinder.cs
@@ -37,7 +37,7 @@ namespace Neptunium.Core.Media.Metadata
 
                             await Task.Delay(250); //250 ms sleep
 
-                            await metaSrc.TryFindSongAsync(extendedMetadata, station.PrimaryLocale);
+                            //await metaSrc.TryFindSongAsync(extendedMetadata, station.PrimaryLocale);
 
                             extendedMetadata.JPopAsiaArtistInfo = await ArtistFetcher.FindArtistDataOnJPopAsiaAsync(originalMetadata.Artist.Trim());
 

--- a/src/Neptunium/Core/Media/Metadata/MetadataFinder.cs
+++ b/src/Neptunium/Core/Media/Metadata/MetadataFinder.cs
@@ -27,20 +27,22 @@ namespace Neptunium.Core.Media.Metadata
                 {
                     if ((bool)NepApp.Settings.GetSetting(AppSettings.TryToFindSongMetadata))
                     {
+                        albumData = await metaSrc.TryFindAlbumAsync(originalMetadata.Track, originalMetadata.Artist, station.PrimaryLocale);
+
+                        await Task.Delay(500); //500 ms sleep
+
+                        artistData = await metaSrc.TryFindArtistAsync(originalMetadata.Artist, station.PrimaryLocale);
+
                         try
                         {
-                            albumData = await metaSrc.TryFindAlbumAsync(originalMetadata.Track, originalMetadata.Artist, station.PrimaryLocale);
-
-                            await Task.Delay(250); //250 ms sleep
-
-                            artistData = await metaSrc.TryFindArtistAsync(originalMetadata.Artist, station.PrimaryLocale);
-
-                            await Task.Delay(250); //250 ms sleep
-
                             //await metaSrc.TryFindSongAsync(extendedMetadata, station.PrimaryLocale);
 
                             extendedMetadata.JPopAsiaArtistInfo = await ArtistFetcher.FindArtistDataOnJPopAsiaAsync(originalMetadata.Artist.Trim());
+                        }
+                        catch (Exception) { }
 
+                        try
+                        {
                             extendedMetadata.FanArtTVBackgroundUrl = await FanArtTVFetcher.FetchArtistBackgroundAsync(originalMetadata.Artist.Trim());
                         }
                         catch (Exception) { }

--- a/src/Neptunium/Core/Media/Metadata/MetadataFinder.cs
+++ b/src/Neptunium/Core/Media/Metadata/MetadataFinder.cs
@@ -30,27 +30,17 @@ namespace Neptunium.Core.Media.Metadata
                         try
                         {
                             albumData = await metaSrc.TryFindAlbumAsync(originalMetadata.Track, originalMetadata.Artist, station.PrimaryLocale);
-                        }
-                        catch (Exception)
-                        { }
 
-                        await Task.Delay(250); //250 ms sleep
+                            await Task.Delay(250); //250 ms sleep
 
-                        try
-                        {
                             artistData = await metaSrc.TryFindArtistAsync(originalMetadata.Artist, station.PrimaryLocale);
-                        }
-                        catch (Exception)
-                        { }
 
-                        try
-                        {
+                            await Task.Delay(250); //250 ms sleep
+
+                            await metaSrc.TryFindSongAsync(extendedMetadata, station.PrimaryLocale);
+
                             extendedMetadata.JPopAsiaArtistInfo = await ArtistFetcher.FindArtistDataOnJPopAsiaAsync(originalMetadata.Artist.Trim());
-                        }
-                        catch (Exception) { }
 
-                        try
-                        {
                             extendedMetadata.FanArtTVBackgroundUrl = await FanArtTVFetcher.FetchArtistBackgroundAsync(originalMetadata.Artist.Trim());
                         }
                         catch (Exception) { }

--- a/src/Neptunium/Core/Media/Metadata/MetadataFinder.cs
+++ b/src/Neptunium/Core/Media/Metadata/MetadataFinder.cs
@@ -23,35 +23,38 @@ namespace Neptunium.Core.Media.Metadata
 
             if (Windows.System.Power.PowerManager.EnergySaverStatus != Windows.System.Power.EnergySaverStatus.On)
             {
-                if ((bool)NepApp.Settings.GetSetting(AppSettings.TryToFindSongMetadata))
+                if (NepApp.Network.NetworkUtilizationBehavior == NepAppNetworkManager.NetworkDeterminedAppBehaviorStyle.Normal)
                 {
-                    try
+                    if ((bool)NepApp.Settings.GetSetting(AppSettings.TryToFindSongMetadata))
                     {
-                        albumData = await metaSrc.TryFindAlbumAsync(originalMetadata.Track, originalMetadata.Artist, station.PrimaryLocale);
-                    }
-                    catch (Exception)
-                    { }
+                        try
+                        {
+                            albumData = await metaSrc.TryFindAlbumAsync(originalMetadata.Track, originalMetadata.Artist, station.PrimaryLocale);
+                        }
+                        catch (Exception)
+                        { }
 
-                    await Task.Delay(250); //250 ms sleep
+                        await Task.Delay(250); //250 ms sleep
 
-                    try
-                    {
-                        artistData = await metaSrc.TryFindArtistAsync(originalMetadata.Artist, station.PrimaryLocale);
-                    }
-                    catch (Exception)
-                    { }
+                        try
+                        {
+                            artistData = await metaSrc.TryFindArtistAsync(originalMetadata.Artist, station.PrimaryLocale);
+                        }
+                        catch (Exception)
+                        { }
 
-                    try
-                    {
-                        extendedMetadata.JPopAsiaArtistInfo = await ArtistFetcher.FindArtistDataOnJPopAsiaAsync(originalMetadata.Artist.Trim());
-                    }
-                    catch (Exception) { }
+                        try
+                        {
+                            extendedMetadata.JPopAsiaArtistInfo = await ArtistFetcher.FindArtistDataOnJPopAsiaAsync(originalMetadata.Artist.Trim());
+                        }
+                        catch (Exception) { }
 
-                    try
-                    {
-                        extendedMetadata.FanArtTVBackgroundUrl = await FanArtTVFetcher.FetchArtistBackgroundAsync(originalMetadata.Artist.Trim());
+                        try
+                        {
+                            extendedMetadata.FanArtTVBackgroundUrl = await FanArtTVFetcher.FetchArtistBackgroundAsync(originalMetadata.Artist.Trim());
+                        }
+                        catch (Exception) { }
                     }
-                    catch (Exception) { }
                 }
             }
 

--- a/src/Neptunium/Core/Media/Metadata/MetadataFinder.cs
+++ b/src/Neptunium/Core/Media/Metadata/MetadataFinder.cs
@@ -21,35 +21,38 @@ namespace Neptunium.Core.Media.Metadata
 
             //todo strip out "feat." artists
 
-            if ((bool)NepApp.Settings.GetSetting(AppSettings.TryToFindSongMetadata))
+            if (Windows.System.Power.PowerManager.EnergySaverStatus != Windows.System.Power.EnergySaverStatus.On)
             {
-                try
+                if ((bool)NepApp.Settings.GetSetting(AppSettings.TryToFindSongMetadata))
                 {
-                    albumData = await metaSrc.TryFindAlbumAsync(originalMetadata.Track, originalMetadata.Artist, station.PrimaryLocale);
-                }
-                catch (Exception)
-                { }
+                    try
+                    {
+                        albumData = await metaSrc.TryFindAlbumAsync(originalMetadata.Track, originalMetadata.Artist, station.PrimaryLocale);
+                    }
+                    catch (Exception)
+                    { }
 
-                await Task.Delay(250); //250 ms sleep
+                    await Task.Delay(250); //250 ms sleep
 
-                try
-                {
-                    artistData = await metaSrc.TryFindArtistAsync(originalMetadata.Artist, station.PrimaryLocale);
-                }
-                catch (Exception)
-                { }
+                    try
+                    {
+                        artistData = await metaSrc.TryFindArtistAsync(originalMetadata.Artist, station.PrimaryLocale);
+                    }
+                    catch (Exception)
+                    { }
 
-                try
-                {
-                    extendedMetadata.JPopAsiaArtistInfo = await ArtistFetcher.FindArtistDataOnJPopAsiaAsync(originalMetadata.Artist.Trim());
-                }
-                catch (Exception) { }
+                    try
+                    {
+                        extendedMetadata.JPopAsiaArtistInfo = await ArtistFetcher.FindArtistDataOnJPopAsiaAsync(originalMetadata.Artist.Trim());
+                    }
+                    catch (Exception) { }
 
-                try
-                {
-                    extendedMetadata.FanArtTVBackgroundUrl = await FanArtTVFetcher.FetchArtistBackgroundAsync(originalMetadata.Artist.Trim());
+                    try
+                    {
+                        extendedMetadata.FanArtTVBackgroundUrl = await FanArtTVFetcher.FetchArtistBackgroundAsync(originalMetadata.Artist.Trim());
+                    }
+                    catch (Exception) { }
                 }
-                catch (Exception) { }
             }
 
             //todo cache

--- a/src/Neptunium/Core/Media/Metadata/MusicBrainzMetadataSource.cs
+++ b/src/Neptunium/Core/Media/Metadata/MusicBrainzMetadataSource.cs
@@ -182,5 +182,27 @@ namespace Neptunium.Core.Media.Metadata
 
             return null;
         }
+
+        public async override Task TryFindSongAsync(ExtendedSongMetadata song, string locale = "JP")
+        {
+            var recordingQuery = new Hqub.MusicBrainz.API.QueryParameters<Hqub.MusicBrainz.API.Entities.Recording>();
+
+            //artistQuery.Add("inc", "url-rels");
+
+            recordingQuery.Add("artist", song.Artist);
+
+            recordingQuery.Add("recording", song.Track);
+
+            recordingQuery.Add("country", locale);
+
+            var recordingResults = await Recording.SearchAsync(recordingQuery);
+
+            var recording = recordingResults?.Items.FirstOrDefault();
+
+            if (recording != null)
+            {
+                song.SongLength = TimeSpan.FromMilliseconds(recording.Length);
+            }
+        }
     }
 }

--- a/src/Neptunium/Core/Media/Metadata/SongMetadata.cs
+++ b/src/Neptunium/Core/Media/Metadata/SongMetadata.cs
@@ -26,6 +26,9 @@ namespace Neptunium.Core.Media.Metadata
         [IgnoreDataMember]
         public string RadioProgram { get; internal set; }
 
+        [DataMember]
+        public TimeSpan SongLength { get; internal set; }
+
         public override string ToString()
         {
             return string.Format("{0} - {1}", Artist ?? "Unknown Artist", Track ?? "Unknown Track");

--- a/src/Neptunium/Core/Media/Metadata/SongMetadata.cs
+++ b/src/Neptunium/Core/Media/Metadata/SongMetadata.cs
@@ -33,6 +33,20 @@ namespace Neptunium.Core.Media.Metadata
         {
             return string.Format("{0} - {1}", Artist ?? "Unknown Artist", Track ?? "Unknown Track");
         }
+
+        internal static SongMetadata Parse(string str)
+        {
+            if (string.IsNullOrWhiteSpace(str)) return null;
+
+            SongMetadata data = new SongMetadata();
+
+            string[] bits = str.Split(new string[] { " - " }, 2, StringSplitOptions.None);
+
+            data.Artist = bits[0].Trim();
+            data.Track = bits[1].Trim();
+
+            return data;
+        }
     }
 
     public class ExtendedSongMetadata: SongMetadata

--- a/src/Neptunium/Core/Media/NepAppMediaPlayerManager.cs
+++ b/src/Neptunium/Core/Media/NepAppMediaPlayerManager.cs
@@ -237,7 +237,7 @@ namespace Neptunium.Media
 
             SetMediaEngagement(true);
 
-            NepApp.Stations.SetLastPlayedStationName(stream.ParentStation.Name);
+            NepApp.Stations.SetLastPlayedStation(stream.ParentStation.Name, DateTime.Now);
 
             if (streamer.SongMetadata == null)
             {

--- a/src/Neptunium/Core/Media/NepAppMediaPlayerManager.cs
+++ b/src/Neptunium/Core/Media/NepAppMediaPlayerManager.cs
@@ -1,4 +1,5 @@
 ﻿using Neptunium.Core;
+using Neptunium.Core.Media.Audio;
 using Neptunium.Core.Media.Bluetooth;
 using Neptunium.Core.Media.History;
 using Neptunium.Core.Media.Metadata;
@@ -28,6 +29,7 @@ namespace Neptunium.Media
         public BasicNepAppMediaStreamer CurrentStreamer { get; private set; }
         internal StationStream CurrentStream { get; private set; }
         public NepAppMediaBluetoothManager Bluetooth { get; private set; }
+        public NepAppAudioManager Audio { get; private set; }
         private MediaPlayer CurrentPlayer { get; set; }
         public SystemMediaTransportControls MediaTransportControls { get; private set; }
         private MediaPlaybackSession CurrentPlayerSession { get; set; }
@@ -59,6 +61,7 @@ namespace Neptunium.Media
         {
             playLock = new SemaphoreSlim(1);
             Bluetooth = new NepAppMediaBluetoothManager(this);
+            Audio = new NepAppAudioManager(this);
 
             sleepTimer.Tick += SleepTimer_Tick;
         }

--- a/src/Neptunium/Core/Media/NepAppMediaPlayerManager.cs
+++ b/src/Neptunium/Core/Media/NepAppMediaPlayerManager.cs
@@ -241,12 +241,9 @@ namespace Neptunium.Media
             SetMediaEngagement(true);
 
             NepApp.Stations.SetLastPlayedStation(stream.ParentStation.Name, DateTime.Now);
+            NepApp.SongManager.SetCurrentMetadataToUnknown();
 
-            if (streamer.SongMetadata == null)
-            {
-                NepApp.SongManager.SetCurrentMetadataToUnknown();
-            }
-            else
+            if (streamer.SongMetadata != null)
             {
                 NepApp.SongManager.HandleMetadata(streamer.SongMetadata, stream);
             }

--- a/src/Neptunium/Core/Media/Songs/NepAppSongManager.cs
+++ b/src/Neptunium/Core/Media/Songs/NepAppSongManager.cs
@@ -231,6 +231,12 @@ namespace Neptunium.Media.Songs
 
                     CurrentSongWithAdditionalMetadata = newMetadata;
 
+                    if (newMetadata != null)
+                    {
+                        CurrentSong.SongLength = newMetadata.SongLength;
+                        RaisePropertyChanged(nameof(CurrentSong));
+                    }
+
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
                     History.AddSongAsync(newMetadata);
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed

--- a/src/Neptunium/Core/Media/Songs/NepAppSongManager.cs
+++ b/src/Neptunium/Core/Media/Songs/NepAppSongManager.cs
@@ -118,6 +118,23 @@ namespace Neptunium.Media.Songs
             blockProgrammingLock.Release();
         }
 
+        internal void RefreshMetadata()
+        {
+            if (CurrentSong == null || CurrentStation == null)
+            {
+                SetCurrentMetadataToUnknown();
+            }
+            else
+            {
+                //this is used for the now playing bar via data binding.
+                RaisePropertyChanged(nameof(CurrentSong));
+
+                PreSongChanged?.Invoke(this, new NepAppSongChangedEventArgs(CurrentSong));
+
+                UpdateTransportControls(CurrentSong);
+            }
+        }
+
         private bool FilterStationBlockPrograms(StationProgram program)
         {
             if (program.Style != StationProgramStyle.Block)
@@ -262,10 +279,17 @@ namespace Neptunium.Media.Songs
             }
             catch (Exception ex)
             {
-                Dictionary<string, string> properties = new Dictionary<string, string>();
-                properties.Add("Song-Metadata", songMetadata?.ToString());
-                properties.Add("Current-Station", currentStream?.ParentStation?.Name);
-                Microsoft.HockeyApp.HockeyClient.Current.TrackException(ex, properties);
+                if (!Debugger.IsAttached)
+                {
+                    Dictionary<string, string> properties = new Dictionary<string, string>();
+                    properties.Add("Song-Metadata", songMetadata?.ToString());
+                    properties.Add("Current-Station", currentStream?.ParentStation?.Name);
+                    Microsoft.HockeyApp.HockeyClient.Current.TrackException(ex, properties);
+                }
+                else
+                {
+                    Debugger.Break();
+                }
             }
             finally
             {

--- a/src/Neptunium/Core/Media/Songs/NepAppSongManager.cs
+++ b/src/Neptunium/Core/Media/Songs/NepAppSongManager.cs
@@ -160,9 +160,14 @@ namespace Neptunium.Media.Songs
 
         internal async void HandleMetadata(SongMetadata songMetadata, StationStream currentStream)
         {
-            if (songMetadata.IsUnknownMetadata) return;
-
             await metadataLock.WaitAsync();
+
+            if (songMetadata == null || songMetadata.IsUnknownMetadata)
+            {
+                SetCurrentMetadataToUnknown();
+                metadataLock.Release();
+                return;
+            }
 
             try
             {

--- a/src/Neptunium/Core/Media/Songs/NepAppSongManager.cs
+++ b/src/Neptunium/Core/Media/Songs/NepAppSongManager.cs
@@ -153,6 +153,8 @@ namespace Neptunium.Media.Songs
 
         internal async void HandleMetadata(SongMetadata songMetadata, StationStream currentStream)
         {
+            if (songMetadata.IsUnknownMetadata) return;
+
             await metadataLock.WaitAsync();
 
             try

--- a/src/Neptunium/Core/Media/Songs/NepAppSongManager.cs
+++ b/src/Neptunium/Core/Media/Songs/NepAppSongManager.cs
@@ -297,6 +297,15 @@ namespace Neptunium.Media.Songs
             }
         }
 
+        internal SongMetadata GetCurrentSongOrUnknown()
+        {
+            if (CurrentStation == null) return null;
+
+            if (CurrentSong != null) return CurrentSong;
+
+            return GetUnknownSongMetadata();
+        }
+
         internal void SetCurrentStation(StationItem parentStation)
         {
             CurrentStation = parentStation;
@@ -318,18 +327,25 @@ namespace Neptunium.Media.Songs
             CurrentSongWithAdditionalMetadata = null;
         }
 
-        internal void SetCurrentMetadataToUnknown(string program = null)
+        private SongMetadata GetUnknownSongMetadata(StationItem stationPlaying = null, string radioProgram = null)
         {
-            //todo make a readonly field
             SongMetadata unknown = new SongMetadata()
             {
                 Track = "Unknown Song",
                 Artist = "Unknown Artist",
-                RadioProgram = program,
-                StationPlayedOn = NepApp.MediaPlayer.CurrentStream?.ParentStation?.Name,
-                StationLogo = NepApp.MediaPlayer.CurrentStream?.ParentStation?.StationLogoUrl,
+                RadioProgram = radioProgram,
+                StationPlayedOn = (stationPlaying ?? CurrentStation)?.Name,
+                StationLogo = (stationPlaying ?? CurrentStation)?.StationLogoUrl,
                 IsUnknownMetadata = true
             };
+
+            return unknown;
+        }
+
+        internal void SetCurrentMetadataToUnknown(string program = null)
+        {
+            //todo make a readonly field
+            SongMetadata unknown = GetUnknownSongMetadata();
 
             CurrentSong = unknown;
             //this is used for the now playing bar via data binding.

--- a/src/Neptunium/Core/Media/Songs/NepAppSongManager.cs
+++ b/src/Neptunium/Core/Media/Songs/NepAppSongManager.cs
@@ -400,7 +400,12 @@ namespace Neptunium.Media.Songs
                 Func<StationProgram, bool> getStationProgram = x =>
                 {
                     if (x.Style != StationProgramStyle.Hosted) return false;
-                    if (x.Host.ToLower().Equals(songMetadata.Artist.Trim().ToLower())) return true;
+
+                    if (!string.IsNullOrWhiteSpace(x.Host))
+                    {
+                        if (x.Host.ToLower().Equals(songMetadata.Artist.Trim().ToLower())) return true;
+                    }
+
                     if (!string.IsNullOrWhiteSpace(x.HostRegexExpression))
                     {
                         if (Regex.IsMatch(songMetadata.Artist, x.HostRegexExpression))

--- a/src/Neptunium/Core/Media/Songs/NepAppSongManager.cs
+++ b/src/Neptunium/Core/Media/Songs/NepAppSongManager.cs
@@ -218,14 +218,6 @@ namespace Neptunium.Media.Songs
 
                     PreSongChanged?.Invoke(this, new NepAppSongChangedEventArgs(songMetadata));
 
-
-
-                    if ((bool)NepApp.Settings.GetSetting(AppSettings.SaySongNotificationsWhenHeadphonesAreConnected) 
-                        && NepApp.MediaPlayer.Audio.HeadsetDetector.IsHeadsetPluggedIn)
-                    {
-                        await VoiceUtility.AnnonceSongMetadataUsingVoiceAsync(songMetadata, VoiceMode.Headphones);
-                    }
-
                     UpdateTransportControls(songMetadata);
 
                     //todo strip out "Feat." artists

--- a/src/Neptunium/Core/Media/Songs/NepAppSongManager.cs
+++ b/src/Neptunium/Core/Media/Songs/NepAppSongManager.cs
@@ -59,16 +59,9 @@ namespace Neptunium.Media.Songs
             VoiceUtility.SongAnnouncementFinished += VoiceUtility_SongAnnouncementFinished;
         }
 
-        private async void VoiceUtility_SongAnnouncementFinished(object sender, EventArgs e)
+        private void VoiceUtility_SongAnnouncementFinished(object sender, EventArgs e)
         {
-            if (NepApp.MediaPlayer.IsPlaying && CurrentSong != null)
-            {
-                //sometimes, the media transport controls will drop the metadata when an announcement plays. this here is to help bring it back. what actually works is pausing and then resuming. however, that isn't nice.
 
-                UpdateTransportControls(new SongMetadata() { Artist = "", Track = "", StationPlayedOn = "" });
-                await Task.Delay(1000);
-                UpdateTransportControls(CurrentSong);
-            }
         }
 
         private void DeactivateProgramBlockTimer()
@@ -224,6 +217,14 @@ namespace Neptunium.Media.Songs
                     CurrentSongWithAdditionalMetadata = null;
 
                     PreSongChanged?.Invoke(this, new NepAppSongChangedEventArgs(songMetadata));
+
+
+
+                    if ((bool)NepApp.Settings.GetSetting(AppSettings.SaySongNotificationsWhenHeadphonesAreConnected) 
+                        && NepApp.MediaPlayer.Audio.HeadsetDetector.IsHeadsetPluggedIn)
+                    {
+                        await VoiceUtility.AnnonceSongMetadataUsingVoiceAsync(songMetadata, VoiceMode.Headphones);
+                    }
 
                     UpdateTransportControls(songMetadata);
 

--- a/src/Neptunium/Core/Media/VoiceUtility.cs
+++ b/src/Neptunium/Core/Media/VoiceUtility.cs
@@ -45,7 +45,6 @@ namespace Neptunium.Core.Media
                         x.Language.ToLower().StartsWith("kr") && x.Gender == VoiceGender.Female);
                 }
 
-                //todo make this a utility in its own class.
                 await announcementLock.WaitAsync();
 
                 var nowPlayingSsmlData = GenerateSongAnnouncementSsml(songMetadata.Artist, songMetadata.Track, NepApp.MediaPlayer.CurrentStream.ParentStation.PrimaryLocale);

--- a/src/Neptunium/Core/Media/VoiceUtility.cs
+++ b/src/Neptunium/Core/Media/VoiceUtility.cs
@@ -1,0 +1,227 @@
+﻿using Crystal3;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Windows.Media.Core;
+using Windows.Media.Playback;
+using Windows.Media.SpeechSynthesis;
+
+namespace Neptunium.Core.Media
+{
+    public static class VoiceUtility
+    {
+        private static SemaphoreSlim announcementLock = new SemaphoreSlim(1);
+
+        private static SpeechSynthesizer speechSynth = new SpeechSynthesizer();
+        private static VoiceInformation japaneseFemaleVoice = null;
+        private static VoiceInformation koreanFemaleVoice = null;
+
+        public static event EventHandler SongAnnouncementFinished;
+
+        public static async Task AnnonceSongMetadataUsingVoiceAsync(Neptunium.Media.Songs.NepAppSongChangedEventArgs e, VoiceMode voiceMode)
+        {
+            try
+            {
+                if (e.Metadata.IsUnknownMetadata) return;
+
+                if (japaneseFemaleVoice == null)
+                {
+                    japaneseFemaleVoice = SpeechSynthesizer.AllVoices.FirstOrDefault(x => x.Language.ToLower().StartsWith("ja") && x.Gender == VoiceGender.Female && x.DisplayName.Contains("Haruka"));
+                }
+
+                if (koreanFemaleVoice == null)
+                {
+                    koreanFemaleVoice = SpeechSynthesizer.AllVoices.FirstOrDefault(x =>
+                        x.Language.ToLower().StartsWith("kr") && x.Gender == VoiceGender.Female);
+                }
+
+                //todo make this a utility in its own class.
+                await announcementLock.WaitAsync();
+
+                var nowPlayingSsmlData = GenerateSongAnnouncementSsml(e.Metadata.Artist, e.Metadata.Track, NepApp.MediaPlayer.CurrentStream.ParentStation.PrimaryLocale);
+                var stream = await speechSynth.SynthesizeSsmlToStreamAsync(nowPlayingSsmlData);
+
+                if (voiceMode == VoiceMode.Bluetooth)
+                {
+                    double initialVolume = NepApp.MediaPlayer.Volume;
+                    bool shouldFade = initialVolume >= 0.1;
+
+                    if (shouldFade) await NepApp.MediaPlayer.FadeVolumeDownToAsync(0.1);
+                    await PlayAnnouncementAudioStreamAsync(stream, voiceMode);
+                    if (shouldFade) await NepApp.MediaPlayer.FadeVolumeUpToAsync(initialVolume);
+                }
+                else
+                {
+                    NepApp.MediaPlayer.Pause();
+                    await PlayAnnouncementAudioStreamAsync(stream, voiceMode);
+                    NepApp.MediaPlayer.Resume();
+                }
+
+                announcementLock.Release();
+
+                SongAnnouncementFinished?.Invoke(null, EventArgs.Empty);
+            }
+            catch (Exception ex)
+            {
+
+            }
+        }
+
+        private static async Task PlayAnnouncementAudioStreamAsync(SpeechSynthesisStream stream, VoiceMode voiceMode)
+        {
+            await await CrystalApplication.Dispatcher.RunWhenIdleAsync(async () =>
+            {
+                var source = MediaSource.CreateFromStream(stream, stream.ContentType);
+
+                var media = new MediaPlayer();
+
+                //media.AudioCategory = MediaPlayerAudioCategory.Speech;
+                if (voiceMode == VoiceMode.Bluetooth)
+                {
+                    media.AudioCategory = MediaPlayerAudioCategory.Media; //Speech is too low.
+                }
+                else if (voiceMode == VoiceMode.Headphones)
+                {
+                    media.AudioCategory = MediaPlayerAudioCategory.Alerts;
+                }
+
+                media.CommandManager.IsEnabled = false;
+                media.Volume = 1.0;
+
+                media.Source = source;
+
+                Task mediaOpenTask = media.WaitForMediaOpenAsync();
+
+                media.Play();
+
+                await mediaOpenTask;
+
+                await Task.Delay((int)media.PlaybackSession.NaturalDuration.TotalMilliseconds);
+
+                source.Dispose();
+
+                stream.Dispose();
+
+                media.Dispose();
+            });
+        }
+
+        private static string GenerateSongAnnouncementSsml(string artist, string title, string locale = "ja")
+        {
+            StringBuilder builder = new StringBuilder();
+
+            var englishVoice = SpeechSynthesizer.AllVoices.Where(x => x.Language.ToLower().StartsWith("en")).First(x => x.Gender == VoiceGender.Female);
+
+            var phrases = new string[] {
+                "Now Playing: {1} by {0}",
+                "And Now: {1} by {0}",
+                "Playing: {1} by {0}",
+            };
+            //                "君が{0}の{1}を聞いています"
+
+            var randomizer = new Random(DateTime.Now.Millisecond);
+            var index = randomizer.Next(0, phrases.Length - 1);
+
+            var phrase = phrases[index];
+
+            bool nativeVoiceAvailable = false;
+            switch (locale.ToLower().Trim())
+            {
+                case "ja":
+                    nativeVoiceAvailable = japaneseFemaleVoice != null;
+                    break;
+                case "kr":
+                    nativeVoiceAvailable = koreanFemaleVoice != null;
+                    break;
+            }
+
+            if (index == 3 && nativeVoiceAvailable)
+                index = 1;
+
+            builder.AppendLine(@"<?xml version='1.0' encoding='ISO-8859-1'?>");
+            builder.AppendLine(@"<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xml:lang='en-US'>");
+            builder.AppendLine("<voice gender='female'>");
+
+            Action<string> speakInEnglish = (text) =>
+            {
+                builder.AppendLine(text);
+            };
+            Action<string> speakInJapanese = (text) =>
+            {
+                //var voice = (japaneseVoiceAvailable ? japaneseFemaleVoice : SpeechSynthesizer.DefaultVoice);
+
+                //builder.AppendLine("<voice xml:lang='" + voice.Language + "' name='" + voice.DisplayName + "'>");
+                builder.AppendLine("<s>");
+                builder.AppendLine("<voice" + (japaneseFemaleVoice != null ? " name='" + japaneseFemaleVoice.DisplayName + "'" : " gender='female'") + ">");
+
+                builder.AppendLine(text);
+                builder.AppendLine("</voice>");
+                builder.AppendLine("</s>");
+            };
+            Action<string> speakInKorean = (text) =>
+            {
+                builder.AppendLine("<s>");
+                builder.AppendLine("<voice" + (koreanFemaleVoice != null ? " name='" + koreanFemaleVoice.DisplayName + "'" : " gender='female'") + ">");
+
+                builder.AppendLine(text);
+                builder.AppendLine("</voice>");
+                builder.AppendLine("</s>");
+            };
+
+            Action<string> speakInNativeLanguage = (text) =>
+            {
+                if (nativeVoiceAvailable)
+                {
+                    switch (locale.ToLower().Trim())
+                    {
+                        case "ja":
+                            speakInJapanese(text);
+                            break;
+                        case "kr":
+                            speakInKorean(text);
+                            break;
+                    }
+                }
+                else
+                {
+                    //fallback to english
+                    speakInEnglish(text);
+                }
+            };
+
+            switch (index)
+            {
+                case 0:
+                    speakInEnglish("Now Playing:");
+                    speakInNativeLanguage(title);
+                    speakInEnglish("By");
+                    speakInNativeLanguage(artist);
+                    break;
+                case 1:
+                    speakInEnglish("And Now:");
+                    speakInNativeLanguage(title);
+                    speakInEnglish("By");
+                    speakInNativeLanguage(artist);
+                    break;
+                case 2:
+                    speakInEnglish("Playing:");
+                    speakInNativeLanguage(title);
+                    speakInEnglish("By");
+                    speakInNativeLanguage(artist);
+                    break;
+            }
+            builder.AppendLine("</voice>");
+            builder.AppendLine("</speak>");
+            return builder.ToString();
+        }
+    }
+
+    public enum VoiceMode
+    {
+        Bluetooth,
+        Headphones
+    }
+}

--- a/src/Neptunium/Core/Media/VoiceUtility.cs
+++ b/src/Neptunium/Core/Media/VoiceUtility.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Windows.Media.Core;
 using Windows.Media.Playback;
 using Windows.Media.SpeechSynthesis;
+using Windows.UI.Xaml.Controls;
 
 namespace Neptunium.Core.Media
 {
@@ -19,6 +20,7 @@ namespace Neptunium.Core.Media
         private static SpeechSynthesizer speechSynth = new SpeechSynthesizer();
         private static VoiceInformation japaneseFemaleVoice = null;
         private static VoiceInformation koreanFemaleVoice = null;
+        private static MediaElement announcementMediaElement = new MediaElement();
 
         public static event EventHandler SongAnnouncementFinished;
 
@@ -72,38 +74,34 @@ namespace Neptunium.Core.Media
             {
                 var source = MediaSource.CreateFromStream(stream, stream.ContentType);
 
-                var media = new MediaPlayer();
-
                 //media.AudioCategory = MediaPlayerAudioCategory.Speech;
                 if (voiceMode == VoiceMode.Bluetooth)
                 {
-                    media.AudioCategory = MediaPlayerAudioCategory.Media; //Speech is too low.
+                    announcementMediaElement.AudioCategory = Windows.UI.Xaml.Media.AudioCategory.Media; //Speech is too low.
                 }
                 else if (voiceMode == VoiceMode.Headphones)
                 {
-                    media.AudioCategory = MediaPlayerAudioCategory.Alerts;
+                    announcementMediaElement.AudioCategory = Windows.UI.Xaml.Media.AudioCategory.Alerts;
                 }
 
-                media.CommandManager.IsEnabled = false;
-                media.Volume = 1.0;
+                //media.CommandManager.IsEnabled = false;
+                announcementMediaElement.Volume = 1.0;
 
-                media.Source = source;
+                announcementMediaElement.SetPlaybackSource(source);
 
-                Task mediaOpenTask = media.WaitForMediaOpenAsync();
+                Task mediaOpenTask = announcementMediaElement.WaitForMediaOpenAsync();
 
-                media.Play();
+                announcementMediaElement.Play();
 
                 await mediaOpenTask;
 
-                await Task.Delay((int)media.PlaybackSession.NaturalDuration.TotalMilliseconds);
-
-                media.SystemMediaTransportControls.DisplayUpdater.ClearAll();
+                await Task.Delay((int)announcementMediaElement.NaturalDuration.TimeSpan.TotalMilliseconds);
 
                 source.Dispose();
 
                 stream.Dispose();
 
-                media.Dispose();
+                //media.Dispose();
             });
         }
 

--- a/src/Neptunium/Core/Media/VoiceUtility.cs
+++ b/src/Neptunium/Core/Media/VoiceUtility.cs
@@ -142,7 +142,11 @@ namespace Neptunium.Core.Media
 
             Action<string> speakInEnglish = (text) =>
             {
+                builder.AppendLine("<s>");
+                builder.AppendLine("<prosody volume='x-loud'>");
                 builder.AppendLine(text);
+                builder.AppendLine("</prosody>");
+                builder.AppendLine("</s>");
             };
             Action<string> speakInJapanese = (text) =>
             {
@@ -151,8 +155,9 @@ namespace Neptunium.Core.Media
                 //builder.AppendLine("<voice xml:lang='" + voice.Language + "' name='" + voice.DisplayName + "'>");
                 builder.AppendLine("<s>");
                 builder.AppendLine("<voice" + (japaneseFemaleVoice != null ? " name='" + japaneseFemaleVoice.DisplayName + "'" : " gender='female'") + ">");
-
+                builder.AppendLine("<prosody volume='x-loud'>");
                 builder.AppendLine(text);
+                builder.AppendLine("</prosody>");
                 builder.AppendLine("</voice>");
                 builder.AppendLine("</s>");
             };
@@ -160,8 +165,9 @@ namespace Neptunium.Core.Media
             {
                 builder.AppendLine("<s>");
                 builder.AppendLine("<voice" + (koreanFemaleVoice != null ? " name='" + koreanFemaleVoice.DisplayName + "'" : " gender='female'") + ">");
-
+                builder.AppendLine("<prosody volume='x-loud'>");
                 builder.AppendLine(text);
+                builder.AppendLine("</prosody>");
                 builder.AppendLine("</voice>");
                 builder.AppendLine("</s>");
             };

--- a/src/Neptunium/Core/NepApp.cs
+++ b/src/Neptunium/Core/NepApp.cs
@@ -31,6 +31,7 @@ namespace Neptunium
         public static NepAppSettingsManager Settings { get; private set; }
         public static NepAppStationsManager Stations { get; private set; }
         public static NepAppUIManager UI { get; private set; }
+        public static NepAppServerFrontEndManager ServerFrontEnd {get;private set;}
 
         public static event EventHandler InitializationComplete;
 
@@ -52,10 +53,20 @@ namespace Neptunium
             SongManager = new NepAppSongManager();
             MediaPlayer = new NepAppMediaPlayerManager();
             Network = new NepAppNetworkManager();
-            Handoff = new NepAppHandoffManager();
-            UI = new NepAppUIManager();
 
-            await Handoff.InitializeAsync();
+            if (App.GetDevicePlatform() != Crystal3.Core.Platform.IoT)
+            {
+                Handoff = new NepAppHandoffManager();
+                UI = new NepAppUIManager();
+
+                await Handoff.InitializeAsync();
+            }
+            else
+            {
+                //specifically for IoT, we start a server
+                ServerFrontEnd = new NepAppServerFrontEndManager();
+                await ServerFrontEnd.InitializeAsync();
+            }
 
             InitializationComplete?.Invoke(null, EventArgs.Empty);
 

--- a/src/Neptunium/Core/NepApp.cs
+++ b/src/Neptunium/Core/NepApp.cs
@@ -35,6 +35,8 @@ namespace Neptunium
 
         public static event EventHandler InitializationComplete;
 
+        public static bool IsServerMode { get; private set; }
+
         public static async Task InitializeAsync()
         {
             CookieJar.ApplicationName = "Neptunium";
@@ -64,13 +66,12 @@ namespace Neptunium
             else
             {
                 //specifically for IoT, we start a server
+                IsServerMode = true;
                 ServerFrontEnd = new NepAppServerFrontEndManager();
                 await ServerFrontEnd.InitializeAsync();
             }
 
             InitializationComplete?.Invoke(null, EventArgs.Empty);
-
-            //return Task.CompletedTask;
         }
 
         public static Binding CreateBinding(INepAppFunctionManager source, string propertyPath, Action<Binding> customizerFunction = null)

--- a/src/Neptunium/Core/NepAppHandoffManager.cs
+++ b/src/Neptunium/Core/NepAppHandoffManager.cs
@@ -82,7 +82,10 @@ namespace Neptunium
 
                 if (Windows.System.Power.PowerManager.EnergySaverStatus != Windows.System.Power.EnergySaverStatus.On)
                 {
-                    remoteSystemWatcher.Start(); //auto runs for 30 seconds. stops when app is suspended - https://docs.microsoft.com/en-us/uwp/api/windows.system.remotesystems.remotesystemwatcher
+                    if ((int)NepApp.Network.ConnectionType > 1) //wifi or ethernet
+                    {
+                        remoteSystemWatcher.Start(); //auto runs for 30 seconds. stops when app is suspended - https://docs.microsoft.com/en-us/uwp/api/windows.system.remotesystems.remotesystemwatcher
+                    }
                 }
             }
         }
@@ -91,7 +94,10 @@ namespace Neptunium
         {
             if (Windows.System.Power.PowerManager.EnergySaverStatus != Windows.System.Power.EnergySaverStatus.On)
             {
-                remoteSystemWatcher.Start();
+                if ((int)NepApp.Network.ConnectionType > 1) //wifi or ethernet
+                {
+                    remoteSystemWatcher.Start();
+                }
             }
         }
 
@@ -249,7 +255,13 @@ namespace Neptunium
             if (!IsSupported) return;
             if (RemoteSystemAccess != RemoteSystemAccessStatus.Allowed) return;
 
-            remoteSystemWatcher.Start();
+            if (Windows.System.Power.PowerManager.EnergySaverStatus != Windows.System.Power.EnergySaverStatus.On)
+            {
+                if ((int)NepApp.Network.ConnectionType > 1) //wifi or ethernet
+                {
+                    remoteSystemWatcher.Start();
+                }
+            }
         }
 
         public async Task<List<Tuple<RemoteSystem, StationItem, AppServiceConnection>>> DetectStreamingDevicesAsync()

--- a/src/Neptunium/Core/NepAppHandoffManager.cs
+++ b/src/Neptunium/Core/NepAppHandoffManager.cs
@@ -79,13 +79,20 @@ namespace Neptunium
                 App.Current.EnteredBackground += Current_EnteredBackground;
                 App.Current.LeavingBackground += Current_LeavingBackground;
 
-                remoteSystemWatcher.Start(); //auto runs for 30 seconds. stops when app is suspended - https://docs.microsoft.com/en-us/uwp/api/windows.system.remotesystems.remotesystemwatcher
+
+                if (Windows.System.Power.PowerManager.EnergySaverStatus != Windows.System.Power.EnergySaverStatus.On)
+                {
+                    remoteSystemWatcher.Start(); //auto runs for 30 seconds. stops when app is suspended - https://docs.microsoft.com/en-us/uwp/api/windows.system.remotesystems.remotesystemwatcher
+                }
             }
         }
 
         private void Current_LeavingBackground(object sender, LeavingBackgroundEventArgs e)
         {
-            remoteSystemWatcher.Start();
+            if (Windows.System.Power.PowerManager.EnergySaverStatus != Windows.System.Power.EnergySaverStatus.On)
+            {
+                remoteSystemWatcher.Start();
+            }
         }
 
         private void Current_EnteredBackground(object sender, EnteredBackgroundEventArgs e)

--- a/src/Neptunium/Core/NepAppNetworkManager.cs
+++ b/src/Neptunium/Core/NepAppNetworkManager.cs
@@ -1,10 +1,11 @@
 ﻿using System;
+using System.ComponentModel;
 using Windows.Networking.Connectivity;
 using static Neptunium.NepApp;
 
 namespace Neptunium
 {
-    public class NepAppNetworkManager : INepAppFunctionManager
+    public class NepAppNetworkManager : INepAppFunctionManager, INotifyPropertyChanged
     {
         public NepAppNetworkManager()
         {
@@ -32,6 +33,7 @@ namespace Neptunium
             {              
                 DetectConnectionType();
                 IsConnectedChanged?.Invoke(this, EventArgs.Empty);
+                RaisePropertyChanged(nameof(IsConnected));
             }
         }
 
@@ -59,6 +61,8 @@ namespace Neptunium
             {
                 ConnectionType = NetworkConnectionType.Unknown; //none?
             }
+
+            RaisePropertyChanged(nameof(ConnectionType));
 
             UpdateNetworkUtilizationBehavior();
         }
@@ -95,10 +99,14 @@ namespace Neptunium
                 {
                     NetworkUtilizationBehavior = NetworkDeterminedAppBehaviorStyle.Normal;
                 }
+
+                RaisePropertyChanged(nameof(NetworkUtilizationBehavior));
             }
         }
 
         public event EventHandler IsConnectedChanged;
+        public event PropertyChangedEventHandler PropertyChanged;
+
         public bool IsConnected { get; private set; }
 
         public NetworkDeterminedAppBehaviorStyle NetworkUtilizationBehavior { get; private set; }
@@ -117,6 +125,14 @@ namespace Neptunium
             WiFi = 2,
             CellularData = 1,
             Unknown = 0
+        }
+
+        private void RaisePropertyChanged(string propertyName)
+        {
+            App.Dispatcher.RunWhenIdleAsync(() =>
+            {
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+            });
         }
     }
 }

--- a/src/Neptunium/Core/NepAppNetworkManager.cs
+++ b/src/Neptunium/Core/NepAppNetworkManager.cs
@@ -1,15 +1,17 @@
-﻿using Windows.Networking.Connectivity;
+﻿using System;
+using Windows.Networking.Connectivity;
 using static Neptunium.NepApp;
 
 namespace Neptunium
 {
-    public class NepAppNetworkManager: INepAppFunctionManager
+    public class NepAppNetworkManager : INepAppFunctionManager
     {
         public NepAppNetworkManager()
         {
             NetworkInformation.NetworkStatusChanged += NetworkInformation_NetworkStatusChanged;
 
             IsConnected = IsInternetConnected();
+            UpdateNetworkUtilizationBehavior();
         }
 
         private bool IsInternetConnected()
@@ -28,10 +30,49 @@ namespace Neptunium
 
             if (oldStatus != newStatus)
             {
-                //todo fire an event stating that the connection changed.
+                IsConnectedChanged?.Invoke(this, EventArgs.Empty);
+                UpdateNetworkUtilizationBehavior();
             }
         }
 
+        private void UpdateNetworkUtilizationBehavior()
+        {
+            //https://docs.microsoft.com/en-us/previous-versions/windows/apps/jj835821(v=win.10)
+            ConnectionProfile connections = NetworkInformation.GetInternetConnectionProfile();
+
+            if (connections != null)
+            {
+                var cost = connections.GetConnectionCost();
+                var dataPlan = connections.GetDataPlanStatus();
+
+                if (cost.NetworkCostType == NetworkCostType.Unrestricted || cost.NetworkCostType == NetworkCostType.Unknown)
+                {
+                    NetworkUtilizationBehavior = NetworkDeterminedAppBehaviorStyle.Normal;
+                }
+                else if (cost.NetworkCostType == NetworkCostType.Fixed || cost.NetworkCostType == NetworkCostType.Variable)
+                {
+                    if (!cost.Roaming && !cost.OverDataLimit)
+                    {
+                        NetworkUtilizationBehavior = NetworkDeterminedAppBehaviorStyle.Conservative;
+                    }
+                    else
+                    {
+                        NetworkUtilizationBehavior = NetworkDeterminedAppBehaviorStyle.OptIn;
+                    }
+                }
+            }
+        }
+
+        public event EventHandler IsConnectedChanged;
         public bool IsConnected { get; private set; }
+
+        public NetworkDeterminedAppBehaviorStyle NetworkUtilizationBehavior { get; private set; }
+
+        public enum NetworkDeterminedAppBehaviorStyle
+        {
+            Normal,
+            Conservative,
+            OptIn
+        }
     }
 }

--- a/src/Neptunium/Core/NepAppNetworkManager.cs
+++ b/src/Neptunium/Core/NepAppNetworkManager.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Net;
 using Windows.Networking.Connectivity;
 using static Neptunium.NepApp;
+using System.Linq;
 
 namespace Neptunium
 {
@@ -30,7 +32,7 @@ namespace Neptunium
             IsConnected = newStatus;
 
             if (oldStatus != newStatus)
-            {              
+            {
                 DetectConnectionType();
                 IsConnectedChanged?.Invoke(this, EventArgs.Empty);
                 RaisePropertyChanged(nameof(IsConnected));
@@ -65,6 +67,29 @@ namespace Neptunium
             RaisePropertyChanged(nameof(ConnectionType));
 
             UpdateNetworkUtilizationBehavior();
+        }
+
+        internal IPAddress GetLocalIPAddress()
+        {
+            //based on: https://stackoverflow.com/a/33774534
+
+            var icp = NetworkInformation.GetInternetConnectionProfile();
+
+            if (icp?.NetworkAdapter == null) return null;
+            var hostname =
+                NetworkInformation.GetHostNames()
+                    .FirstOrDefault(
+                        hn =>
+                            hn.IPInformation?.NetworkAdapter != null && hn.IPInformation.NetworkAdapter.NetworkAdapterId
+                            == icp.NetworkAdapter.NetworkAdapterId);
+
+            if (hostname != null)
+            {
+                // the ip address
+                return IPAddress.Parse(hostname?.CanonicalName);
+            }
+
+            return null;
         }
 
         private void UpdateNetworkUtilizationBehavior()

--- a/src/Neptunium/Core/NepAppNetworkManager.cs
+++ b/src/Neptunium/Core/NepAppNetworkManager.cs
@@ -164,5 +164,39 @@ namespace Neptunium
                 PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
             });
         }
+
+        #region FROM: https://stackoverflow.com/a/43068327
+        public IPAddress GetSubnetMask(IPAddress hostAddress)
+        {
+            var addressBytes = hostAddress.GetAddressBytes();
+
+            if (addressBytes[0] >= 1 && addressBytes[0] <= 126)
+                return IPAddress.Parse("255.0.0.0");
+            else if (addressBytes[0] >= 128 && addressBytes[0] <= 191)
+                return IPAddress.Parse("255.255.255.0");
+            else if (addressBytes[0] >= 192 && addressBytes[0] <= 223)
+                return IPAddress.Parse("255.255.255.0");
+            else
+                throw new ArgumentOutOfRangeException();
+        }
+
+        public IPAddress GetBroadastAddress(IPAddress hostIPAddress)
+        {
+            var subnetAddress = GetSubnetMask(hostIPAddress);
+
+            var deviceAddressBytes = hostIPAddress.GetAddressBytes();
+            var subnetAddressBytes = subnetAddress.GetAddressBytes();
+
+            if (deviceAddressBytes.Length != subnetAddressBytes.Length)
+                throw new ArgumentOutOfRangeException();
+
+            var broadcastAddressBytes = new byte[deviceAddressBytes.Length];
+
+            for (var i = 0; i < broadcastAddressBytes.Length; i++)
+                broadcastAddressBytes[i] = (byte)(deviceAddressBytes[i] | subnetAddressBytes[i] ^ 255);
+
+            return new IPAddress(broadcastAddressBytes);
+        }
+        #endregion
     }
 }

--- a/src/Neptunium/Core/NepAppNetworkManager.cs
+++ b/src/Neptunium/Core/NepAppNetworkManager.cs
@@ -70,9 +70,9 @@ namespace Neptunium
 
         public enum NetworkDeterminedAppBehaviorStyle
         {
-            Normal,
-            Conservative,
-            OptIn
+            Normal = 2,
+            Conservative = 1,
+            OptIn = 0
         }
     }
 }

--- a/src/Neptunium/Core/NepAppNetworkManager.cs
+++ b/src/Neptunium/Core/NepAppNetworkManager.cs
@@ -4,6 +4,8 @@ using System.Net;
 using Windows.Networking.Connectivity;
 using static Neptunium.NepApp;
 using System.Linq;
+using Windows.Networking;
+using System.Collections.Generic;
 
 namespace Neptunium
 {
@@ -69,27 +71,30 @@ namespace Neptunium
             UpdateNetworkUtilizationBehavior();
         }
 
-        internal IPAddress GetLocalIPAddress()
+        internal IEnumerable<IPAddress> GetLocalIPAddresses()
         {
             //based on: https://stackoverflow.com/a/33774534
 
             var icp = NetworkInformation.GetInternetConnectionProfile();
 
-            if (icp?.NetworkAdapter == null) return null;
-            var hostname =
+            if (icp?.NetworkAdapter == null) yield break;
+            var hostnames =
                 NetworkInformation.GetHostNames()
-                    .FirstOrDefault(
+                    .Where(
                         hn =>
                             hn.IPInformation?.NetworkAdapter != null && hn.IPInformation.NetworkAdapter.NetworkAdapterId
                             == icp.NetworkAdapter.NetworkAdapterId);
 
-            if (hostname != null)
+            if (hostnames != null)
             {
-                // the ip address
-                return IPAddress.Parse(hostname?.CanonicalName);
+                foreach (HostName host in hostnames)
+                {
+                    // the ip address
+                    yield return IPAddress.Parse(host.CanonicalName);
+                }
             }
 
-            return null;
+            yield break;
         }
 
         private void UpdateNetworkUtilizationBehavior()

--- a/src/Neptunium/Core/NepAppNetworkManager.cs
+++ b/src/Neptunium/Core/NepAppNetworkManager.cs
@@ -73,20 +73,27 @@ namespace Neptunium
                 var cost = connections.GetConnectionCost();
                 var dataPlan = connections.GetDataPlanStatus();
 
-                if (cost.NetworkCostType == NetworkCostType.Unrestricted || cost.NetworkCostType == NetworkCostType.Unknown)
+                if ((bool)NepApp.Settings.GetSetting(AppSettings.AutomaticallyConserveDataWhenOnMeteredConnections))
+                {
+                    if (cost.NetworkCostType == NetworkCostType.Unrestricted || cost.NetworkCostType == NetworkCostType.Unknown)
+                    {
+                        NetworkUtilizationBehavior = NetworkDeterminedAppBehaviorStyle.Normal;
+                    }
+                    else if (cost.NetworkCostType == NetworkCostType.Fixed || cost.NetworkCostType == NetworkCostType.Variable)
+                    {
+                        if (!cost.Roaming && !cost.OverDataLimit)
+                        {
+                            NetworkUtilizationBehavior = NetworkDeterminedAppBehaviorStyle.Conservative;
+                        }
+                        else
+                        {
+                            NetworkUtilizationBehavior = NetworkDeterminedAppBehaviorStyle.OptIn;
+                        }
+                    }
+                }
+                else
                 {
                     NetworkUtilizationBehavior = NetworkDeterminedAppBehaviorStyle.Normal;
-                }
-                else if (cost.NetworkCostType == NetworkCostType.Fixed || cost.NetworkCostType == NetworkCostType.Variable)
-                {
-                    if (!cost.Roaming && !cost.OverDataLimit)
-                    {
-                        NetworkUtilizationBehavior = NetworkDeterminedAppBehaviorStyle.Conservative;
-                    }
-                    else
-                    {
-                        NetworkUtilizationBehavior = NetworkDeterminedAppBehaviorStyle.OptIn;
-                    }
                 }
             }
         }

--- a/src/Neptunium/Core/NepAppServerFrontEndManager.cs
+++ b/src/Neptunium/Core/NepAppServerFrontEndManager.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Windows.System.Threading;
+using static Neptunium.NepApp;
+
+namespace Neptunium.Core
+{
+    public class NepAppServerFrontEndManager : INotifyPropertyChanged, INepAppFunctionManager
+    {
+        public const int ServerPortNumber = 8806;
+
+        /// <summary>
+        /// From INotifyPropertyChanged
+        /// </summary>
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        private void RaisePropertyChanged([CallerMemberName] string propertyName = "")
+        {
+            if (string.IsNullOrWhiteSpace(propertyName)) throw new ArgumentNullException("propertyName");
+
+            if (PropertyChanged != null)
+                PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        public class NepAppServerFrontEndManagerDataReceivedEventArgs : EventArgs
+        {
+            public string Data { get; private set; }
+            internal NepAppServerFrontEndManagerDataReceivedEventArgs(string data)
+            {
+                Data = data;
+            }
+        }
+
+        public bool IsInitialized { get; private set; }
+        public EndPoint LocalEndPoint { get; private set; }
+
+        public event EventHandler<NepAppServerFrontEndManagerDataReceivedEventArgs> DataReceived;
+
+
+        private Task serverRunningTask = null;
+        private CancellationTokenSource serverTaskCancelTokenSrc = null;
+
+        public async Task InitializeAsync()
+        {
+            if (IsInitialized) return;
+
+            serverTaskCancelTokenSrc = new CancellationTokenSource();
+            serverRunningTask = new Task(HandleServer, serverTaskCancelTokenSrc.Token);
+
+            serverRunningTask.Start();
+
+            IsInitialized = true;
+        }
+
+        private async void HandleServer()
+        {
+            List<Socket> connections = new List<Socket>();
+
+            TcpListener listener = new TcpListener(IPAddress.Any, ServerPortNumber);
+            listener.Start();
+
+            LocalEndPoint = listener.LocalEndpoint;
+            RaisePropertyChanged(nameof(LocalEndPoint));
+
+            while (!serverTaskCancelTokenSrc.IsCancellationRequested)
+            {
+                if (listener.Pending())
+                {
+                    connections.Add(await listener.AcceptSocketAsync());
+                }
+
+                List<Socket> sockets = connections.ToList();
+                Socket.Select(sockets, null, null, 20); //figure out which ones have data available to read.
+
+                foreach(var socket in sockets)
+                {
+                    byte[] data = new byte[2048];
+                    socket.Receive(data);
+
+                    var dataString = Encoding.Unicode.GetString(data);
+
+                    await ThreadPool.RunAsync(new WorkItemHandler(x =>
+                    {
+                        DataReceived?.Invoke(this, new NepAppServerFrontEndManagerDataReceivedEventArgs(dataString));
+                    }));
+                }
+            }
+
+            //clean up
+            listener.Stop();
+
+            foreach(Socket client in connections)
+            {
+                client.Dispose();
+            }
+
+            connections.Clear();
+
+            LocalEndPoint = null;
+            RaisePropertyChanged(nameof(LocalEndPoint));
+        }
+    }
+}

--- a/src/Neptunium/Core/NepAppServerFrontEndManager.cs
+++ b/src/Neptunium/Core/NepAppServerFrontEndManager.cs
@@ -315,6 +315,9 @@ namespace Neptunium.Core
                     if (disposing)
                     {
                         // TODO: dispose managed state (managed objects).
+                        if (readerTaskCancellationSource == null) return;
+                        if (tcpClient == null) return;
+
                         readerTaskCancellationSource.Cancel();
 
                         IsConnected = false;

--- a/src/Neptunium/Core/Settings/NepAppSettingsManager.cs
+++ b/src/Neptunium/Core/Settings/NepAppSettingsManager.cs
@@ -38,6 +38,10 @@ namespace Neptunium.Core.Settings
             if (!ApplicationData.Current.LocalSettings.Values.ContainsKey(Enum.GetName(typeof(AppSettings), AppSettings.AutomaticallyDetermineAppropriateBitrateBasedOnConnection)))
                 ApplicationData.Current.LocalSettings.Values.Add(Enum.GetName(typeof(AppSettings), AppSettings.AutomaticallyDetermineAppropriateBitrateBasedOnConnection), true);
 
+            if (!ApplicationData.Current.LocalSettings.Values.ContainsKey(Enum.GetName(typeof(AppSettings), AppSettings.ShowRemoteMenu)))
+                ApplicationData.Current.LocalSettings.Values.Add(Enum.GetName(typeof(AppSettings), AppSettings.ShowRemoteMenu), false);
+            
+
             //bluetooth mode stuff
             if (!ApplicationData.Current.LocalSettings.Values.ContainsKey(Enum.GetName(typeof(AppSettings), AppSettings.SaySongNotificationsInBluetoothMode)))
                 ApplicationData.Current.LocalSettings.Values.Add(Enum.GetName(typeof(AppSettings), AppSettings.SaySongNotificationsInBluetoothMode), false);

--- a/src/Neptunium/Core/Settings/NepAppSettingsManager.cs
+++ b/src/Neptunium/Core/Settings/NepAppSettingsManager.cs
@@ -40,7 +40,10 @@ namespace Neptunium.Core.Settings
 
             if (!ApplicationData.Current.LocalSettings.Values.ContainsKey(Enum.GetName(typeof(AppSettings), AppSettings.ShowRemoteMenu)))
                 ApplicationData.Current.LocalSettings.Values.Add(Enum.GetName(typeof(AppSettings), AppSettings.ShowRemoteMenu), false);
-            
+
+            if (!ApplicationData.Current.LocalSettings.Values.ContainsKey(Enum.GetName(typeof(AppSettings), AppSettings.SaySongNotificationsWhenHeadphonesAreConnected)))
+                ApplicationData.Current.LocalSettings.Values.Add(Enum.GetName(typeof(AppSettings), AppSettings.SaySongNotificationsWhenHeadphonesAreConnected), false);
+
 
             //bluetooth mode stuff
             if (!ApplicationData.Current.LocalSettings.Values.ContainsKey(Enum.GetName(typeof(AppSettings), AppSettings.SaySongNotificationsInBluetoothMode)))

--- a/src/Neptunium/Core/Settings/NepAppSettingsManager.cs
+++ b/src/Neptunium/Core/Settings/NepAppSettingsManager.cs
@@ -33,6 +33,11 @@ namespace Neptunium.Core.Settings
             if (!ApplicationData.Current.LocalSettings.Values.ContainsKey(Enum.GetName(typeof(AppSettings), AppSettings.UpdateLockScreenWithSongArt)))
                 ApplicationData.Current.LocalSettings.Values.Add(Enum.GetName(typeof(AppSettings), AppSettings.UpdateLockScreenWithSongArt), false);
 
+            if (!ApplicationData.Current.LocalSettings.Values.ContainsKey(Enum.GetName(typeof(AppSettings), AppSettings.AutomaticallyConserveDataWhenOnMeteredConnections)))
+                ApplicationData.Current.LocalSettings.Values.Add(Enum.GetName(typeof(AppSettings), AppSettings.AutomaticallyConserveDataWhenOnMeteredConnections), true);
+            if (!ApplicationData.Current.LocalSettings.Values.ContainsKey(Enum.GetName(typeof(AppSettings), AppSettings.AutomaticallyDetermineAppropriateBitrateBasedOnConnection)))
+                ApplicationData.Current.LocalSettings.Values.Add(Enum.GetName(typeof(AppSettings), AppSettings.AutomaticallyDetermineAppropriateBitrateBasedOnConnection), true);
+
             //bluetooth mode stuff
             if (!ApplicationData.Current.LocalSettings.Values.ContainsKey(Enum.GetName(typeof(AppSettings), AppSettings.SaySongNotificationsInBluetoothMode)))
                 ApplicationData.Current.LocalSettings.Values.Add(Enum.GetName(typeof(AppSettings), AppSettings.SaySongNotificationsInBluetoothMode), false);

--- a/src/Neptunium/Core/Settings/NepAppSettingsManager.cs
+++ b/src/Neptunium/Core/Settings/NepAppSettingsManager.cs
@@ -1,9 +1,7 @@
-﻿using System;
+﻿using Crystal3;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using Windows.Storage;
 using static Neptunium.NepApp;
 
@@ -29,7 +27,19 @@ namespace Neptunium.Core.Settings
             if (!ApplicationData.Current.LocalSettings.Values.ContainsKey(Enum.GetName(typeof(AppSettings), AppSettings.PreferUsingCrossFadeWhenChangingStations)))
                 ApplicationData.Current.LocalSettings.Values.Add(Enum.GetName(typeof(AppSettings), AppSettings.PreferUsingCrossFadeWhenChangingStations), true);
             if (!ApplicationData.Current.LocalSettings.Values.ContainsKey(Enum.GetName(typeof(AppSettings), AppSettings.UseHapticFeedbackForNavigation)))
-                ApplicationData.Current.LocalSettings.Values.Add(Enum.GetName(typeof(AppSettings), AppSettings.UseHapticFeedbackForNavigation), true);
+            {
+                ApplicationData.Current.LocalSettings.Values.Add(Enum.GetName(typeof(AppSettings), AppSettings.UseHapticFeedbackForNavigation), CrystalApplication.GetDevicePlatform() == Crystal3.Core.Platform.Mobile);
+            }
+            else
+            {
+                //ensure that for Xbox, this is always false.
+
+                if (CrystalApplication.GetDevicePlatform() == Crystal3.Core.Platform.Xbox)
+                {
+                    SetSetting(AppSettings.UseHapticFeedbackForNavigation, false);
+                }
+            }
+
             if (!ApplicationData.Current.LocalSettings.Values.ContainsKey(Enum.GetName(typeof(AppSettings), AppSettings.UpdateLockScreenWithSongArt)))
                 ApplicationData.Current.LocalSettings.Values.Add(Enum.GetName(typeof(AppSettings), AppSettings.UpdateLockScreenWithSongArt), false);
 

--- a/src/Neptunium/Core/Stations/NepAppStationsManager.cs
+++ b/src/Neptunium/Core/Stations/NepAppStationsManager.cs
@@ -213,7 +213,7 @@ namespace Neptunium.Core.Stations
                     {
                         //hosted programs rely on the "artist" string (from song metadata) to match in order to activate.
 
-                        program.Host = x.Attribute("Host").Value;
+                        program.Host = x.Attribute("Host")?.Value;
                         program.HostRegexExpression = x.Attribute("HostExp")?.Value;
                     }
                     else if (program.Style == StationProgramStyle.Block)

--- a/src/Neptunium/Core/Stations/NepAppStationsManager.cs
+++ b/src/Neptunium/Core/Stations/NepAppStationsManager.cs
@@ -30,12 +30,23 @@ namespace Neptunium.Core.Stations
             {
                 LastPlayedStationName = (string)ApplicationData.Current.RoamingSettings.Values[nameof(LastPlayedStationName)];
             }
+
+            if (!ApplicationData.Current.RoamingSettings.Values.ContainsKey(nameof(LastPlayedStationDate)))
+            {
+                ApplicationData.Current.RoamingSettings.Values.Add(new KeyValuePair<string, object>(nameof(LastPlayedStationDate), null));
+            }
+            else
+            {
+                LastPlayedStationDate = DateTime.Parse(ApplicationData.Current.RoamingSettings.Values[nameof(LastPlayedStationDate)].ToString());
+            }
         }
 
-        internal void SetLastPlayedStationName(string value)
+        internal void SetLastPlayedStation(string value, DateTime time)
         {
             LastPlayedStationName = value;
+            LastPlayedStationDate = time;
             ApplicationData.Current.RoamingSettings.Values[nameof(LastPlayedStationName)] = value;
+            ApplicationData.Current.RoamingSettings.Values[nameof(LastPlayedStationDate)] = time.ToString();
         }
 
         private async Task<StorageFile> GetStationsFileAsync()
@@ -53,6 +64,7 @@ namespace Neptunium.Core.Stations
         }
 
         public string LastPlayedStationName { get; private set; }
+        public DateTime LastPlayedStationDate { get; private set; }
 
         internal async Task<StationItem[]> GetStationsAsync()
         {

--- a/src/Neptunium/Core/Stations/NepAppStationsManager.cs
+++ b/src/Neptunium/Core/Stations/NepAppStationsManager.cs
@@ -232,7 +232,7 @@ namespace Neptunium.Core.Stations
         internal async Task<StationItem> GetStationByNameAsync(string stationPlayedOn)
         {
             //ugly way to do this
-            var station = (await GetStationsAsync()).First(x => x.Name.Equals(stationPlayedOn));
+            var station = (await GetStationsAsync()).FirstOrDefault(x => x.Name.Equals(stationPlayedOn));
             return station;
         }
     }

--- a/src/Neptunium/Core/Stations/NepAppStationsManager.cs
+++ b/src/Neptunium/Core/Stations/NepAppStationsManager.cs
@@ -2,6 +2,9 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -82,145 +85,7 @@ namespace Neptunium.Core.Stations
 
                 foreach (var stationElement in xmlDoc.Element("Stations").Elements("Station"))
                 {
-                    var streams = stationElement.Element("Streams").Elements("Stream").Select<XElement, StationStream>(x =>
-                    {
-                        var stream = new StationStream(new Uri(x.Value));
-                        stream.ContentType = x.Attribute("ContentType")?.Value;
-
-                        if (x.Attribute("Bitrate") != null)
-                            stream.Bitrate = int.Parse(x.Attribute("Bitrate")?.Value);
-
-                        if (x.Attribute("RelativePath") != null)
-                            stream.RelativePath = x.Attribute("RelativePath")?.Value;
-
-                        if (x.Attribute("ServerType") != null)
-                        {
-                            stream.ServerFormat = (StationStreamServerFormat)Enum.Parse(typeof(StationStreamServerFormat), x.Attribute("ServerType").Value);
-                        }
-
-                        if (x.Attribute("RequestMetadata") != null)
-                        {
-                            stream.RequestMetadata = bool.Parse(x.Attribute("RequestMetadata").Value);
-                        }
-                        else
-                        {
-                            //defaults to true
-                            stream.RequestMetadata = true;
-                        }
-
-                        return stream;
-                    }).ToArray();
-
-                    var stationLogoData = await NepApp.CacheManager.GetOrCacheUriAsync(NepAppDataCacheManager.CacheType.StationImages, new Uri(stationElement.Element("Logo").Value));
-                    Uri stationLogoUri = stationLogoData.Item1;
-                    if (stationLogoData.Item2 != null)
-                        stationLogoUri = new Uri(stationLogoData.Item2.Path);
-
-
-                    var station = new StationItem(
-                        name: stationElement.Element("Name").Value,
-                        description: stationElement.Element("Description").Value,
-                        stationLogo: stationLogoUri,
-                        streams: streams);
-
-                    station.StationLogoUrlOnline = new Uri(stationElement.Element("Logo").Value);
-
-                    if (stationElement.Element("Programs") != null)
-                    {
-                        station.Programs = stationElement.Element("Programs").Elements("Program").Select<XElement, StationProgram>(x =>
-                        {
-
-                            var program = new StationProgram();
-                            program.Name = x.Attribute("Name")?.Value;
-                            program.Station = station;
-
-                            if (x.Attribute("Style") != null)
-                            {
-                                program.Style = (StationProgramStyle)Enum.Parse(typeof(StationProgramStyle), x.Attribute("Style").Value);
-                            }
-                            else
-                            {
-                                program.Style = StationProgramStyle.Hosted;
-                            }
-
-                            if (program.Style == StationProgramStyle.Hosted)
-                            {
-                                //hosted programs rely on the "artist" string (from song metadata) to match in order to activate.
-
-                                program.Host = x.Attribute("Host").Value;
-                                program.HostRegexExpression = x.Attribute("HostExp")?.Value;
-                            }
-                            else if (program.Style == StationProgramStyle.Block)
-                            {
-                                //block programs are activated based on the time and the current station.
-                            }
-
-                            if (x.HasElements)
-                            {
-                                if (x.Elements("Listing") != null)
-                                {
-                                    //if the program has an actual schedule (e.g. always occur on a certain day around a certain time), grab its time listings.
-
-                                    var listings = new List<StationProgramTimeListing>();
-
-                                    foreach (var listingElement in x.Elements("Listing"))
-                                    {
-                                        try
-                                        {
-                                            StationProgramTimeListing listing = new StationProgramTimeListing();
-                                            listing.Day = (DayOfWeek)Enum.Parse(typeof(DayOfWeek), listingElement.Attribute("Day").Value);
-                                            listing.Time = DateTime.Parse(listingElement.Attribute("Time").Value);
-
-                                            if (listingElement.Attribute("EndTime") != null)
-                                            {
-                                                listing.EndTime = DateTime.Parse(listingElement.Attribute("EndTime").Value);
-                                            }
-
-                                            listings.Add(listing);
-                                        }
-                                        catch (Exception ex)
-                                        {
-#if !DEBUG
-                                            Microsoft.HockeyApp.HockeyClient.Current.TrackException(ex);
-#endif
-                                        }
-                                    }
-
-                                    program.TimeListings = listings.ToArray();
-                                }
-                            }
-
-                            return program;
-                        }).ToArray();
-                    }
-                    else
-                    {
-                        station.Programs = null;
-                    }
-
-                    if (stationElement.Element("Background") != null)
-                    {
-                        var backgroundElement = stationElement.Element("Background");
-
-                        station.Background = backgroundElement.Value;
-                    }
-
-                    station.Site = stationElement.Element("Site").Value;
-                    station.Genres = stationElement.Element("Genres").Value.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
-                    station.PrimaryLocale = stationElement.Element("PrimaryLocale")?.Value;
-
-                    if (stationElement.Element("StationMessages") == null)
-                    {
-                        station.StationMessages = new string[] { };
-                    }
-                    else
-                    {
-                        var stationMsgElement = stationElement.Element("StationMessages");
-                        var messages = stationMsgElement.Elements("Message").Select(x => x.Value.ToString()).ToArray();
-                        station.StationMessages = messages;
-                    }
-
-                    station.Group = stationElement.Element("StationGroup")?.Value;
+                    var station = await ConvertStationElementToStationAsync(stationElement);
 
                     stationList.Add(station);
 
@@ -239,6 +104,191 @@ namespace Neptunium.Core.Stations
                 xmlDoc = null;
                 reader.Dispose();
             }
+        }
+
+        internal IObservable<StationItem> ObserveStationsAsync()
+        {
+            return Observable.Create<StationItem>(async o =>
+            {
+                await stationsLock.WaitAsync();
+
+                StorageFile file = await GetStationsFileAsync();
+
+                var reader = await file.OpenReadAsync();
+
+                XDocument xmlDoc = XDocument.Load(reader.AsStream());
+
+                try
+                {
+                    foreach (var stationElement in xmlDoc.Element("Stations").Elements("Station"))
+                    {
+                        var station = await ConvertStationElementToStationAsync(stationElement);
+
+                        o.OnNext(station);
+                    }
+
+                    stationsLock.Release();
+                }
+                catch (Exception ex)
+                {
+                    stationsLock.Release();
+                    o.OnError(new Exception("An error occurred", ex));
+                }
+                finally
+                {
+                    xmlDoc = null;
+                    reader.Dispose();
+
+                    o.OnCompleted();
+                }
+
+                return Disposable.Empty;
+            });
+        }
+
+        private async Task<StationItem> ConvertStationElementToStationAsync(XElement stationElement)
+        {
+            var streams = stationElement.Element("Streams").Elements("Stream").Select<XElement, StationStream>(x =>
+            {
+                var stream = new StationStream(new Uri(x.Value));
+                stream.ContentType = x.Attribute("ContentType")?.Value;
+
+                if (x.Attribute("Bitrate") != null)
+                    stream.Bitrate = int.Parse(x.Attribute("Bitrate")?.Value);
+
+                if (x.Attribute("RelativePath") != null)
+                    stream.RelativePath = x.Attribute("RelativePath")?.Value;
+
+                if (x.Attribute("ServerType") != null)
+                {
+                    stream.ServerFormat = (StationStreamServerFormat)Enum.Parse(typeof(StationStreamServerFormat), x.Attribute("ServerType").Value);
+                }
+
+                if (x.Attribute("RequestMetadata") != null)
+                {
+                    stream.RequestMetadata = bool.Parse(x.Attribute("RequestMetadata").Value);
+                }
+                else
+                {
+                    //defaults to true
+                    stream.RequestMetadata = true;
+                }
+
+                return stream;
+            }).ToArray();
+
+            var stationLogoData = await NepApp.CacheManager.GetOrCacheUriAsync(NepAppDataCacheManager.CacheType.StationImages, new Uri(stationElement.Element("Logo").Value));
+            Uri stationLogoUri = stationLogoData.Item1;
+            if (stationLogoData.Item2 != null)
+                stationLogoUri = new Uri(stationLogoData.Item2.Path);
+
+
+            var station = new StationItem(
+                name: stationElement.Element("Name").Value,
+                description: stationElement.Element("Description").Value,
+                stationLogo: stationLogoUri,
+                streams: streams);
+
+            station.StationLogoUrlOnline = new Uri(stationElement.Element("Logo").Value);
+
+            if (stationElement.Element("Programs") != null)
+            {
+                station.Programs = stationElement.Element("Programs").Elements("Program").Select<XElement, StationProgram>(x =>
+                {
+
+                    var program = new StationProgram();
+                    program.Name = x.Attribute("Name")?.Value;
+                    program.Station = station;
+
+                    if (x.Attribute("Style") != null)
+                    {
+                        program.Style = (StationProgramStyle)Enum.Parse(typeof(StationProgramStyle), x.Attribute("Style").Value);
+                    }
+                    else
+                    {
+                        program.Style = StationProgramStyle.Hosted;
+                    }
+
+                    if (program.Style == StationProgramStyle.Hosted)
+                    {
+                        //hosted programs rely on the "artist" string (from song metadata) to match in order to activate.
+
+                        program.Host = x.Attribute("Host").Value;
+                        program.HostRegexExpression = x.Attribute("HostExp")?.Value;
+                    }
+                    else if (program.Style == StationProgramStyle.Block)
+                    {
+                        //block programs are activated based on the time and the current station.
+                    }
+
+                    if (x.HasElements)
+                    {
+                        if (x.Elements("Listing") != null)
+                        {
+                            //if the program has an actual schedule (e.g. always occur on a certain day around a certain time), grab its time listings.
+
+                            var listings = new List<StationProgramTimeListing>();
+
+                            foreach (var listingElement in x.Elements("Listing"))
+                            {
+                                try
+                                {
+                                    StationProgramTimeListing listing = new StationProgramTimeListing();
+                                    listing.Day = (DayOfWeek)Enum.Parse(typeof(DayOfWeek), listingElement.Attribute("Day").Value);
+                                    listing.Time = DateTime.Parse(listingElement.Attribute("Time").Value);
+
+                                    if (listingElement.Attribute("EndTime") != null)
+                                    {
+                                        listing.EndTime = DateTime.Parse(listingElement.Attribute("EndTime").Value);
+                                    }
+
+                                    listings.Add(listing);
+                                }
+                                catch (Exception ex)
+                                {
+#if !DEBUG
+                                            Microsoft.HockeyApp.HockeyClient.Current.TrackException(ex);
+#endif
+                                }
+                            }
+
+                            program.TimeListings = listings.ToArray();
+                        }
+                    }
+
+                    return program;
+                }).ToArray();
+            }
+            else
+            {
+                station.Programs = null;
+            }
+
+            if (stationElement.Element("Background") != null)
+            {
+                var backgroundElement = stationElement.Element("Background");
+
+                station.Background = backgroundElement.Value;
+            }
+
+            station.Site = stationElement.Element("Site").Value;
+            station.Genres = stationElement.Element("Genres").Value.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+            station.PrimaryLocale = stationElement.Element("PrimaryLocale")?.Value;
+
+            if (stationElement.Element("StationMessages") == null)
+            {
+                station.StationMessages = new string[] { };
+            }
+            else
+            {
+                var stationMsgElement = stationElement.Element("StationMessages");
+                var messages = stationMsgElement.Elements("Message").Select(x => x.Value.ToString()).ToArray();
+                station.StationMessages = messages;
+            }
+
+            station.Group = stationElement.Element("StationGroup")?.Value;
+
+            return station;
         }
 
         internal async Task<StationItem> GetStationByNameAsync(string stationPlayedOn)

--- a/src/Neptunium/Core/UI/NepAppUIManager.cs
+++ b/src/Neptunium/Core/UI/NepAppUIManager.cs
@@ -109,23 +109,45 @@ namespace Neptunium.Core.UI
                 PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
         }
 
-        public async Task ShowInfoDialogAsync(string title, string message)
+        public async Task<IUICommand> ShowInfoDialogAsync(string title, string message, IEnumerable<IUICommand> commands = null)
         {
             if (App.Dispatcher.HasThreadAccess)
             {
                 MessageDialog dialog = new MessageDialog(message);
                 dialog.Title = title;
-                await dialog.ShowAsync();
+                if (commands != null)
+                {
+                    foreach(IUICommand command in commands)
+                    {
+                        dialog.Commands.Add(command);
+                    }
+                }
+                return await dialog.ShowAsync();
             }
             else
             {
-                await await App.Dispatcher.RunWhenIdleAsync(() =>
+                return await await App.Dispatcher.RunWhenIdleAsync(() =>
                 {
                     MessageDialog dialog = new MessageDialog(message);
                     dialog.Title = title;
+                    if (commands != null)
+                    {
+                        foreach (IUICommand command in commands)
+                        {
+                            dialog.Commands.Add(command);
+                        }
+                    }
                     return dialog.ShowAsync();
                 });
             }
+        }
+        public async Task<bool> ShowYesNoDialogAsync(string title, string message, IEnumerable<IUICommand> commands = null)
+        {
+            var yes = new UICommand("Yes");
+            var no = new UICommand("No");
+            var result = await ShowInfoDialogAsync(title, message, new IUICommand[] { yes, no });
+
+            return result == yes;
         }
         #endregion
 

--- a/src/Neptunium/Core/UI/NepAppUIManager.cs
+++ b/src/Neptunium/Core/UI/NepAppUIManager.cs
@@ -111,12 +111,21 @@ namespace Neptunium.Core.UI
 
         public async Task ShowInfoDialogAsync(string title, string message)
         {
-            await await App.Dispatcher.RunWhenIdleAsync(() =>
+            if (App.Dispatcher.HasThreadAccess)
             {
                 MessageDialog dialog = new MessageDialog(message);
                 dialog.Title = title;
-                return dialog.ShowAsync();
-            });
+                await dialog.ShowAsync();
+            }
+            else
+            {
+                await await App.Dispatcher.RunWhenIdleAsync(() =>
+                {
+                    MessageDialog dialog = new MessageDialog(message);
+                    dialog.Title = title;
+                    return dialog.ShowAsync();
+                });
+            }
         }
         #endregion
 

--- a/src/Neptunium/Core/UI/NepAppUIManager.cs
+++ b/src/Neptunium/Core/UI/NepAppUIManager.cs
@@ -141,7 +141,7 @@ namespace Neptunium.Core.UI
                 });
             }
         }
-        public async Task<bool> ShowYesNoDialogAsync(string title, string message, IEnumerable<IUICommand> commands = null)
+        public async Task<bool> ShowYesNoDialogAsync(string title, string message)
         {
             var yes = new UICommand("Yes");
             var no = new UICommand("No");

--- a/src/Neptunium/Core/UI/NepAppUIManager.cs
+++ b/src/Neptunium/Core/UI/NepAppUIManager.cs
@@ -101,6 +101,11 @@ namespace Neptunium.Core.UI
             }
         }
 
+        internal void ClearNavigationRoutes()
+        {
+            navigationItems.Clear();
+        }
+
         private void RaisePropertyChanged([CallerMemberName] string propertyName = "")
         {
             if (string.IsNullOrWhiteSpace(propertyName)) throw new ArgumentNullException("propertyName");

--- a/src/Neptunium/Core/UI/NepAppUIManagerNotifier.cs
+++ b/src/Neptunium/Core/UI/NepAppUIManagerNotifier.cs
@@ -156,6 +156,8 @@ namespace Neptunium.Core.UI
 
         public bool CheckIfStationTilePinned(StationItem stationItem)
         {
+            if (Crystal3.CrystalApplication.GetDevicePlatform() == Crystal3.Core.Platform.Xbox) return false; //not supported
+
             return SecondaryTile.Exists(GetStationItemTileId(stationItem));
         }
 
@@ -284,6 +286,8 @@ namespace Neptunium.Core.UI
 
         public void UpdateLiveTile(ExtendedSongMetadata nowPlaying)
         {
+            if (Crystal3.CrystalApplication.GetDevicePlatform() == Crystal3.Core.Platform.Xbox) return; //not supported
+
             var tiler = TileUpdateManager.CreateTileUpdaterForApplication();
 
             TileBindingContentAdaptive largeBindingContent = new TileBindingContentAdaptive()

--- a/src/Neptunium/Core/UI/NepAppUIManagerNotifier.cs
+++ b/src/Neptunium/Core/UI/NepAppUIManagerNotifier.cs
@@ -6,6 +6,7 @@ using Neptunium.Core.Stations;
 using Windows.UI.StartScreen;
 using System.Threading.Tasks;
 using Windows.UI;
+using Windows.Phone.Devices.Notification;
 
 namespace Neptunium.Core.UI
 {
@@ -13,12 +14,28 @@ namespace Neptunium.Core.UI
     {
         private ToastNotifier toastNotifier = null;
         private TileUpdater tileUpdater = null;
+        private VibrationDevice vibrationDevice = null;
         public const string SongNotificationTag = "song-notif";
 
         internal NepAppUIManagerNotifier()
         {
             toastNotifier = ToastNotificationManager.CreateToastNotifier();
             tileUpdater = TileUpdateManager.CreateTileUpdaterForApplication();
+
+            
+            if (Crystal3.CrystalApplication.GetDevicePlatform() == Crystal3.Core.Platform.Mobile)
+                vibrationDevice = VibrationDevice.GetDefault();
+        }
+
+        public void VibrateClick()
+        {
+            if ((bool)NepApp.Settings.GetSetting(AppSettings.UseHapticFeedbackForNavigation))
+            {
+                if (vibrationDevice != null)
+                {
+                    vibrationDevice?.Vibrate(TimeSpan.FromMilliseconds(32));
+                }
+            }
         }
 
         public void ShowGenericToastNotification(string title, string message, string tag)

--- a/src/Neptunium/Data/BuiltinArtists.xml
+++ b/src/Neptunium/Data/BuiltinArtists.xml
@@ -103,4 +103,23 @@
     <AltName>Hirano Aya</AltName>
     <AltName>平野綾</AltName>
   </Artist>
+  <Artist Name="5dolls" FanArtTVUrl="https://fanart.tv/artist/51af7767-570f-4aea-a9e1-420713a8d9b9/5dolls/">
+  </Artist>
+  <Artist Name="Taeyeon" PartOf="Girls' Generation">
+    <AltName>Taeyeon (Girls' Generation)</AltName>
+  </Artist>
+  <Artist Name="fripSide" JPopAsiaUrl="http://www.jpopasia.com/fripside/">
+  </Artist>
+  <Artist Name="nao" PartOf="fripSide">  
+  </Artist>
+  <Artist Name="Fifteen And" JPopAsiaUrl="http://www.jpopasia.com/15and/">
+    <AltName><![CDATA[15&]]></AltName>
+    <AltName>피프틴앤드</AltName>
+  </Artist>
+  <Artist Name="Park Ji Min" PartOf="Fifteen And">
+    <AltName><![CDATA[Park Ji Min (15&)]]></AltName>
+  </Artist>
+  <Artist Name="2PM" JPopAsiaUrl="http://www.jpopasia.com/2pm/" FanArtTVUrl="https://fanart.tv/artist/9b94ac1a-b997-4414-9385-96178b5ef99c/2pm/">
+    <AltName>투피엠</AltName>
+  </Artist>
 </Artists>

--- a/src/Neptunium/Data/BuiltinArtists.xml
+++ b/src/Neptunium/Data/BuiltinArtists.xml
@@ -99,4 +99,8 @@
   <Artist Name="SISTAR" JPopAsiaUrl="http://www.jpopasia.com/sistar/" FanArtTVUrl="https://fanart.tv/artist/f5bff650-07d0-4f8c-bf48-45497f465b79/sistar/">
     <AltName>씨스타</AltName>
   </Artist>
+  <Artist Name="Aya Hirano" JPopAsiaUrl="http://www.jpopasia.com/ayahirano/" FanArtTVUrl="https://fanart.tv/artist/dfe0486a-d8f7-449a-a1ce-192803b3b537/hirano-aya/">
+    <AltName>Hirano Aya</AltName>
+    <AltName>平野綾</AltName>
+  </Artist>
 </Artists>

--- a/src/Neptunium/Data/BuiltinArtists.xml
+++ b/src/Neptunium/Data/BuiltinArtists.xml
@@ -122,4 +122,9 @@
   <Artist Name="2PM" JPopAsiaUrl="http://www.jpopasia.com/2pm/" FanArtTVUrl="https://fanart.tv/artist/9b94ac1a-b997-4414-9385-96178b5ef99c/2pm/">
     <AltName>투피엠</AltName>
   </Artist>
+  <Artist Name="Apink" JPopAsiaUrl="http://www.jpopasia.com/apink/" FanArtTVUrl="https://fanart.tv/artist/9102bdf6-b03e-4470-9f78-12127c4995cc/apink/">
+  </Artist>
+  <Artist Name="G.NA" JPopAsiaUrl="http://www.jpopasia.com/gna/">
+    <AltName>Gina Choi</AltName>
+  </Artist>
 </Artists>

--- a/src/Neptunium/Neptunium.csproj
+++ b/src/Neptunium/Neptunium.csproj
@@ -458,10 +458,7 @@
       <Version>2.1.1</Version>
     </PackageReference>
     <PackageReference Include="System.Reactive">
-      <Version>3.1.1</Version>
-    </PackageReference>
-    <PackageReference Include="System.Reactive.Core">
-      <Version>3.1.1</Version>
+      <Version>4.0.0</Version>
     </PackageReference>
     <PackageReference Include="Win2D.uwp">
       <Version>1.21.0</Version>

--- a/src/Neptunium/Neptunium.csproj
+++ b/src/Neptunium/Neptunium.csproj
@@ -19,10 +19,13 @@
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <PackageCertificateKeyFile>Neptunium_StoreKey.pfx</PackageCertificateKeyFile>
     <PackageCertificateThumbprint>B1BAEED331682A2E59C08B40B6865F99C24A0170</PackageCertificateThumbprint>
-    <AppxAutoIncrementPackageRevision>True</AppxAutoIncrementPackageRevision>
+    <AppxAutoIncrementPackageRevision>False</AppxAutoIncrementPackageRevision>
     <AppxBundlePlatforms>x86|x64|arm</AppxBundlePlatforms>
     <AppxBundle>Always</AppxBundle>
     <RuntimeIdentifiers>win10-arm;win10-arm-aot;win10-x86;win10-x86-aot;win10-x64;win10-x64-aot</RuntimeIdentifiers>
+    <GenerateAppInstallerFile>False</GenerateAppInstallerFile>
+    <AppInstallerUpdateFrequency>1</AppInstallerUpdateFrequency>
+    <AppInstallerCheckForUpdateFrequency>OnApplicationRun</AppInstallerCheckForUpdateFrequency>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Neptunium/Neptunium.csproj
+++ b/src/Neptunium/Neptunium.csproj
@@ -111,6 +111,10 @@
     </Compile>
     <Compile Include="ApplicationCommands.cs" />
     <Compile Include="AppSettings.cs" />
+    <Compile Include="Core\Media\Audio\IHeadsetDetector.cs" />
+    <Compile Include="Core\Media\Audio\MobileHeadsetDetector.cs" />
+    <Compile Include="Core\Media\Audio\NepAppAudioManager.cs" />
+    <Compile Include="Core\Media\Audio\XboxHeadsetDetector.cs" />
     <Compile Include="Core\Media\Bluetooth\NepAppMediaBluetoothDeviceCoordinator.cs" />
     <Compile Include="Core\Media\Bluetooth\NepAppMediaBluetoothDeviceCoordinatorIsBluetoothConnectedChangedEventArgs.cs" />
     <Compile Include="Core\Media\Bluetooth\NepAppMediaBluetoothManager.cs" />

--- a/src/Neptunium/Neptunium.csproj
+++ b/src/Neptunium/Neptunium.csproj
@@ -180,6 +180,7 @@
     <Compile Include="ViewModel\Dialog\StationInfoDialogFragment.cs" />
     <Compile Include="ViewModel\NowPlayingPageViewModel.cs" />
     <Compile Include="ViewModel\ServerRemotePageViewModel.cs" />
+    <Compile Include="ViewModel\Server\ServerShellViewModel.cs" />
     <Compile Include="ViewModel\SettingsPageViewModel.cs" />
     <Compile Include="ViewModel\SongHistoryPageViewModel.cs" />
     <Compile Include="ViewModel\StationProgramsPageViewModel.cs" />
@@ -199,8 +200,8 @@
     <Compile Include="View\Dialog\StationInfoDialog.xaml.cs">
       <DependentUpon>StationInfoDialog.xaml</DependentUpon>
     </Compile>
-    <Compile Include="View\IoTShellView.xaml.cs">
-      <DependentUpon>IoTShellView.xaml</DependentUpon>
+    <Compile Include="View\ServerShellView.xaml.cs">
+      <DependentUpon>ServerShellView.xaml</DependentUpon>
     </Compile>
     <Compile Include="View\NowPlayingPage.xaml.cs">
       <DependentUpon>NowPlayingPage.xaml</DependentUpon>
@@ -374,7 +375,7 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
-    <Page Include="View\IoTShellView.xaml">
+    <Page Include="View\ServerShellView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/src/Neptunium/Neptunium.csproj
+++ b/src/Neptunium/Neptunium.csproj
@@ -424,7 +424,7 @@
       <Version>4.1.6</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.0.5</Version>
+      <Version>6.1.5</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp">
       <Version>2.1.1</Version>

--- a/src/Neptunium/Neptunium.csproj
+++ b/src/Neptunium/Neptunium.csproj
@@ -403,10 +403,13 @@
     <SDKReference Include="Microsoft.VCLibs, Version=14.0">
       <Name>Visual C++ 2015 Runtime for Universal Windows Platform Apps</Name>
     </SDKReference>
-    <SDKReference Include="WindowsDesktop, Version=10.0.16232.0">
+    <SDKReference Include="WindowsDesktop, Version=10.0.16299.0">
       <Name>Windows Desktop Extensions for the UWP</Name>
     </SDKReference>
-    <SDKReference Include="WindowsMobile, Version=10.0.16232.0">
+    <SDKReference Include="WindowsIoT, Version=10.0.16299.0">
+      <Name>Windows IoT Extensions for the UWP</Name>
+    </SDKReference>
+    <SDKReference Include="WindowsMobile, Version=10.0.17134.0">
       <Name>Windows Mobile Extensions for the UWP</Name>
     </SDKReference>
   </ItemGroup>

--- a/src/Neptunium/Neptunium.csproj
+++ b/src/Neptunium/Neptunium.csproj
@@ -179,6 +179,7 @@
     <Compile Include="ViewModel\Fragments\SleepTimerContextFragment.cs" />
     <Compile Include="ViewModel\Dialog\StationInfoDialogFragment.cs" />
     <Compile Include="ViewModel\NowPlayingPageViewModel.cs" />
+    <Compile Include="ViewModel\ServerRemotePageViewModel.cs" />
     <Compile Include="ViewModel\SettingsPageViewModel.cs" />
     <Compile Include="ViewModel\SongHistoryPageViewModel.cs" />
     <Compile Include="ViewModel\StationProgramsPageViewModel.cs" />
@@ -203,6 +204,9 @@
     </Compile>
     <Compile Include="View\NowPlayingPage.xaml.cs">
       <DependentUpon>NowPlayingPage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="View\ServerRemotePage.xaml.cs">
+      <DependentUpon>ServerRemotePage.xaml</DependentUpon>
     </Compile>
     <Compile Include="View\SettingsPage.xaml.cs">
       <DependentUpon>SettingsPage.xaml</DependentUpon>
@@ -375,6 +379,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="View\NowPlayingPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="View\ServerRemotePage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/src/Neptunium/Neptunium.csproj
+++ b/src/Neptunium/Neptunium.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Core\NepAppHandoffManager.cs" />
     <Compile Include="Core\Media\NepAppMediaPlayerManager.cs" />
     <Compile Include="Core\NepAppNetworkManager.cs" />
+    <Compile Include="Core\NepAppServerFrontEndManager.cs" />
     <Compile Include="Core\Settings\NepAppSettingChangedEventArgs.cs" />
     <Compile Include="Core\Settings\NepAppSettingsManager.cs" />
     <Compile Include="ColorUtilities.cs" />
@@ -196,6 +197,9 @@
     </Compile>
     <Compile Include="View\Dialog\StationInfoDialog.xaml.cs">
       <DependentUpon>StationInfoDialog.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="View\IoTShellView.xaml.cs">
+      <DependentUpon>IoTShellView.xaml</DependentUpon>
     </Compile>
     <Compile Include="View\NowPlayingPage.xaml.cs">
       <DependentUpon>NowPlayingPage.xaml</DependentUpon>
@@ -363,6 +367,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="View\Dialog\StationInfoDialog.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="View\IoTShellView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/src/Neptunium/Neptunium.csproj
+++ b/src/Neptunium/Neptunium.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Core\Media\Songs\NepAppSongMetadataArtworkEventArgs.cs" />
     <Compile Include="Core\Media\Songs\NepAppSongMetadataBackground.cs" />
     <Compile Include="Core\Media\Songs\NepAppStationProgramStartedEventArgs.cs" />
+    <Compile Include="Core\Media\VoiceUtility.cs" />
     <Compile Include="Core\NepAppDataCacheManager.cs" />
     <Compile Include="Core\NepAppHandoffManager.cs" />
     <Compile Include="Core\Media\NepAppMediaPlayerManager.cs" />

--- a/src/Neptunium/Package.appxmanifest
+++ b/src/Neptunium/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" IgnorableNamespaces="uap mp uap3">
-  <Identity Name="61121Amrykid.Neptunium" Publisher="CN=CA7B3C80-E81B-48E1-BF79-9F01D08E6588" Version="0.8.10.0" />
+  <Identity Name="61121Amrykid.Neptunium" Publisher="CN=CA7B3C80-E81B-48E1-BF79-9F01D08E6588" Version="0.8.11.0" />
   <mp:PhoneIdentity PhoneProductId="3e703e44-20da-4846-ab80-ae3d970466d1" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>Neptunium</DisplayName>

--- a/src/Neptunium/Package.appxmanifest
+++ b/src/Neptunium/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" IgnorableNamespaces="uap mp uap3">
-  <Identity Name="61121Amrykid.Neptunium" Publisher="CN=CA7B3C80-E81B-48E1-BF79-9F01D08E6588" Version="0.7.4.0" />
+  <Identity Name="61121Amrykid.Neptunium" Publisher="CN=CA7B3C80-E81B-48E1-BF79-9F01D08E6588" Version="0.8.0.0" />
   <mp:PhoneIdentity PhoneProductId="3e703e44-20da-4846-ab80-ae3d970466d1" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>Neptunium</DisplayName>

--- a/src/Neptunium/Package.appxmanifest
+++ b/src/Neptunium/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" IgnorableNamespaces="uap mp uap3">
-  <Identity Name="61121Amrykid.Neptunium" Publisher="CN=CA7B3C80-E81B-48E1-BF79-9F01D08E6588" Version="0.8.7.0" />
+  <Identity Name="61121Amrykid.Neptunium" Publisher="CN=CA7B3C80-E81B-48E1-BF79-9F01D08E6588" Version="0.8.8.0" />
   <mp:PhoneIdentity PhoneProductId="3e703e44-20da-4846-ab80-ae3d970466d1" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>Neptunium</DisplayName>

--- a/src/Neptunium/Package.appxmanifest
+++ b/src/Neptunium/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" IgnorableNamespaces="uap mp uap3">
-  <Identity Name="61121Amrykid.Neptunium" Publisher="CN=CA7B3C80-E81B-48E1-BF79-9F01D08E6588" Version="0.8.5.0" />
+  <Identity Name="61121Amrykid.Neptunium" Publisher="CN=CA7B3C80-E81B-48E1-BF79-9F01D08E6588" Version="0.8.6.0" />
   <mp:PhoneIdentity PhoneProductId="3e703e44-20da-4846-ab80-ae3d970466d1" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>Neptunium</DisplayName>

--- a/src/Neptunium/Package.appxmanifest
+++ b/src/Neptunium/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" IgnorableNamespaces="uap mp uap3">
-  <Identity Name="61121Amrykid.Neptunium" Publisher="CN=CA7B3C80-E81B-48E1-BF79-9F01D08E6588" Version="0.8.4.0" />
+  <Identity Name="61121Amrykid.Neptunium" Publisher="CN=CA7B3C80-E81B-48E1-BF79-9F01D08E6588" Version="0.8.5.0" />
   <mp:PhoneIdentity PhoneProductId="3e703e44-20da-4846-ab80-ae3d970466d1" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>Neptunium</DisplayName>
@@ -35,6 +35,7 @@
   </Applications>
   <Capabilities>
     <Capability Name="internetClient" />
+    <Capability Name="privateNetworkClientServer" />
     <uap3:Capability Name="backgroundMediaPlayback" />
     <uap3:Capability Name="remoteSystem" />
     <uap:Capability Name="userAccountInformation" />

--- a/src/Neptunium/Package.appxmanifest
+++ b/src/Neptunium/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" IgnorableNamespaces="uap mp uap3">
-  <Identity Name="61121Amrykid.Neptunium" Publisher="CN=CA7B3C80-E81B-48E1-BF79-9F01D08E6588" Version="0.8.9.0" />
+  <Identity Name="61121Amrykid.Neptunium" Publisher="CN=CA7B3C80-E81B-48E1-BF79-9F01D08E6588" Version="0.8.10.0" />
   <mp:PhoneIdentity PhoneProductId="3e703e44-20da-4846-ab80-ae3d970466d1" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>Neptunium</DisplayName>

--- a/src/Neptunium/Package.appxmanifest
+++ b/src/Neptunium/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" IgnorableNamespaces="uap mp uap3">
-  <Identity Name="61121Amrykid.Neptunium" Publisher="CN=CA7B3C80-E81B-48E1-BF79-9F01D08E6588" Version="0.8.6.0" />
+  <Identity Name="61121Amrykid.Neptunium" Publisher="CN=CA7B3C80-E81B-48E1-BF79-9F01D08E6588" Version="0.8.7.0" />
   <mp:PhoneIdentity PhoneProductId="3e703e44-20da-4846-ab80-ae3d970466d1" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>Neptunium</DisplayName>

--- a/src/Neptunium/Package.appxmanifest
+++ b/src/Neptunium/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" IgnorableNamespaces="uap mp uap3">
-  <Identity Name="61121Amrykid.Neptunium" Publisher="CN=CA7B3C80-E81B-48E1-BF79-9F01D08E6588" Version="0.8.0.0" />
+  <Identity Name="61121Amrykid.Neptunium" Publisher="CN=CA7B3C80-E81B-48E1-BF79-9F01D08E6588" Version="0.8.1.0" />
   <mp:PhoneIdentity PhoneProductId="3e703e44-20da-4846-ab80-ae3d970466d1" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>Neptunium</DisplayName>
@@ -21,12 +21,12 @@
         <uap:SplashScreen Image="Assets\SplashScreen.png" />
       </uap:VisualElements>
       <Extensions>
-        <uap3:Extension Category="windows.appService">
-          <uap3:AppService Name="com.Amrykid.CAEAppService" SupportsRemoteSystems="true" />
-        </uap3:Extension>
         <uap:Extension Category="windows.protocol">
           <uap:Protocol Name="nep" />
         </uap:Extension>
+        <uap3:Extension Category="windows.appService">
+          <uap3:AppService Name="com.Amrykid.CAEAppService" SupportsRemoteSystems="true" />
+        </uap3:Extension>
         <!--<uap:Extension Category="windows.appService">
           <uap3:AppService Name="com.Amrykid.CAEAppService" SupportsRemoteSystems="true" />
         </uap:Extension>-->

--- a/src/Neptunium/Package.appxmanifest
+++ b/src/Neptunium/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" IgnorableNamespaces="uap mp uap3">
-  <Identity Name="61121Amrykid.Neptunium" Publisher="CN=CA7B3C80-E81B-48E1-BF79-9F01D08E6588" Version="0.8.8.0" />
+  <Identity Name="61121Amrykid.Neptunium" Publisher="CN=CA7B3C80-E81B-48E1-BF79-9F01D08E6588" Version="0.8.9.0" />
   <mp:PhoneIdentity PhoneProductId="3e703e44-20da-4846-ab80-ae3d970466d1" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>Neptunium</DisplayName>

--- a/src/Neptunium/Package.appxmanifest
+++ b/src/Neptunium/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" IgnorableNamespaces="uap mp uap3">
-  <Identity Name="61121Amrykid.Neptunium" Publisher="CN=CA7B3C80-E81B-48E1-BF79-9F01D08E6588" Version="0.8.3.0" />
+  <Identity Name="61121Amrykid.Neptunium" Publisher="CN=CA7B3C80-E81B-48E1-BF79-9F01D08E6588" Version="0.8.4.0" />
   <mp:PhoneIdentity PhoneProductId="3e703e44-20da-4846-ab80-ae3d970466d1" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>Neptunium</DisplayName>

--- a/src/Neptunium/Package.appxmanifest
+++ b/src/Neptunium/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" IgnorableNamespaces="uap mp uap3">
-  <Identity Name="61121Amrykid.Neptunium" Publisher="CN=CA7B3C80-E81B-48E1-BF79-9F01D08E6588" Version="0.8.1.0" />
+  <Identity Name="61121Amrykid.Neptunium" Publisher="CN=CA7B3C80-E81B-48E1-BF79-9F01D08E6588" Version="0.8.2.0" />
   <mp:PhoneIdentity PhoneProductId="3e703e44-20da-4846-ab80-ae3d970466d1" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>Neptunium</DisplayName>
@@ -21,15 +21,15 @@
         <uap:SplashScreen Image="Assets\SplashScreen.png" />
       </uap:VisualElements>
       <Extensions>
+        <!--<uap:Extension Category="windows.appService">
+          <uap3:AppService Name="com.Amrykid.CAEAppService" SupportsRemoteSystems="true" />
+        </uap:Extension>-->
         <uap:Extension Category="windows.protocol">
           <uap:Protocol Name="nep" />
         </uap:Extension>
         <uap3:Extension Category="windows.appService">
           <uap3:AppService Name="com.Amrykid.CAEAppService" SupportsRemoteSystems="true" />
         </uap3:Extension>
-        <!--<uap:Extension Category="windows.appService">
-          <uap3:AppService Name="com.Amrykid.CAEAppService" SupportsRemoteSystems="true" />
-        </uap:Extension>-->
       </Extensions>
     </Application>
   </Applications>

--- a/src/Neptunium/Package.appxmanifest
+++ b/src/Neptunium/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" IgnorableNamespaces="uap mp uap3">
-  <Identity Name="61121Amrykid.Neptunium" Publisher="CN=CA7B3C80-E81B-48E1-BF79-9F01D08E6588" Version="0.8.2.0" />
+  <Identity Name="61121Amrykid.Neptunium" Publisher="CN=CA7B3C80-E81B-48E1-BF79-9F01D08E6588" Version="0.8.3.0" />
   <mp:PhoneIdentity PhoneProductId="3e703e44-20da-4846-ab80-ae3d970466d1" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>Neptunium</DisplayName>

--- a/src/Neptunium/View/AboutPage.xaml
+++ b/src/Neptunium/View/AboutPage.xaml
@@ -18,6 +18,7 @@
                 <StackPanel Orientation="Horizontal">
                     <AppBarButton Icon="Globe" Label="GitHub" Click="AppBarButton_Click" />
                     <AppBarButton Icon="Shop" Label="Windows Store" Click="AppBarButton_Click_1" />
+                    <AppBarButton Icon="ContactInfo" Label="Privacy Policy" Click="AppBarButton_Click_2" />
                 </StackPanel>
                 
                 <TextBlock Style="{ThemeResource SubtitleTextBlockStyle}" Foreground="{ThemeResource SystemControlForegroundBaseMediumHighBrush}" Text="Introduction" Margin="0 5 0 0" />

--- a/src/Neptunium/View/AboutPage.xaml
+++ b/src/Neptunium/View/AboutPage.xaml
@@ -23,7 +23,7 @@
                 <TextBlock Style="{ThemeResource SubtitleTextBlockStyle}" Foreground="{ThemeResource SystemControlForegroundBaseMediumHighBrush}" Text="Introduction" Margin="0 5 0 0" />
                 <TextBlock Style="{ThemeResource BodyTextBlockStyle}" Foreground="{ThemeResource SystemControlForegroundBaseMediumLowBrush}" Padding="5">
                     Neptunium (or Nep for short) is a reimagining of Hanasu, a streaming radio player catered to Japanese and Korean music. Hanasu began as a proof of concept and a hobby project. 
-                    Neptunium began as an attend to build Hanasu as a Windows 10 Universal application. Neptunium runs on Windows 10 PC, Windows 10 Mobile phones and Xbox One (via Windows 10).
+                    Neptunium began as an attempt to build Hanasu as a Windows 10 Universal application. Neptunium runs on Windows 10 PC, Windows 10 Mobile phones and Xbox One (via Windows 10).
                 </TextBlock>
 
                 <TextBlock Style="{ThemeResource SubtitleTextBlockStyle}" Foreground="{ThemeResource SystemControlForegroundBaseMediumHighBrush}" Text="Libraries Used" />

--- a/src/Neptunium/View/AboutPage.xaml.cs
+++ b/src/Neptunium/View/AboutPage.xaml.cs
@@ -42,6 +42,11 @@ namespace Neptunium.View
         {
             Launcher.LaunchUriAsync(new Uri("https://www.microsoft.com/en-us/store/p/neptunium/9nblggh1r9cq"));
         }
+
+        private void AppBarButton_Click_2(System.Object sender, RoutedEventArgs e)
+        {
+            Launcher.LaunchUriAsync(new Uri("https://github.com/Amrykid/Neptunium/wiki/Privacy-Policy"));
+        }
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
     }
 }

--- a/src/Neptunium/View/AppShellView.xaml
+++ b/src/Neptunium/View/AppShellView.xaml
@@ -41,11 +41,12 @@
                         Grid.Column="0"
                         x:Name="TogglePaneButton"
                         AutomationProperties.Name="Menu"
-                        Click="TogglePaneButton_Click"
+                        Checked="TogglePaneButton_Checked"
                         Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}"
                         Style="{StaticResource SplitViewTogglePaneButtonStyle}"
                         TabIndex="1"
-                        ToolTipService.ToolTip="Menu" />
+                        ToolTipService.ToolTip="Menu"
+                        Unchecked="TogglePaneButton_Unchecked" />
 
                 <TextBlock Name="PageTitleBlock" Grid.Column="1" VerticalAlignment="Center"
                            Style="{ThemeResource BaseTextBlockStyle}" />

--- a/src/Neptunium/View/AppShellView.xaml
+++ b/src/Neptunium/View/AppShellView.xaml
@@ -295,9 +295,15 @@
                             <TextBlock Grid.Row="1" Text="{Binding Artist, UpdateSourceTrigger=PropertyChanged}"
                                        Style="{ThemeResource BodyTextBlockStyle}"
                                        Foreground="{ThemeResource SystemControlForegroundBaseMediumHighBrush}"/>
-                            <TextBlock Grid.Row="2" Text="{Binding StationPlayedOn, UpdateSourceTrigger=PropertyChanged}"
+                            <TextBlock Grid.Row="2"
                                        Style="{ThemeResource CaptionTextBlockStyle}"
-                                       Foreground="{ThemeResource SystemControlForegroundBaseMediumLowBrush}"/>
+                                       Foreground="{ThemeResource SystemControlForegroundBaseMediumLowBrush}">
+                                <Span>
+                                    <Run Text="{Binding StationPlayedOn, UpdateSourceTrigger=PropertyChanged}" />
+                                    <Run Text="·" />
+                                    <Run Text="{Binding RadioProgram, UpdateSourceTrigger=PropertyChanged}" />
+                                </Span>
+                            </TextBlock>
                         </Grid>
 
                     </Grid>

--- a/src/Neptunium/View/AppShellView.xaml
+++ b/src/Neptunium/View/AppShellView.xaml
@@ -134,6 +134,14 @@
                         </Flyout>
                     </AppBarButton.Flyout>
                 </AppBarButton>
+                <AppBarButton Icon="FourBars" ToolTipService.ToolTip="IoT Remote"
+                              Foreground="{ThemeResource SystemControlForegroundChromeWhiteBrush}">
+                    <AppBarButton.Flyout>
+                        <MenuFlyout>
+                            <MenuFlyoutItem Text="Remote" Command="{Binding GoToRemoteCommand}" />
+                        </MenuFlyout>
+                    </AppBarButton.Flyout>
+                </AppBarButton>
             </StackPanel>
         </Grid>
 

--- a/src/Neptunium/View/AppShellView.xaml
+++ b/src/Neptunium/View/AppShellView.xaml
@@ -323,7 +323,7 @@
             <VisualStateGroup x:Name="ShellVisualStateGroup">
                 <VisualState x:Name="DesktopVisualState">
                     <VisualState.StateTriggers>
-                        <wst:AdaptiveTrigger MinWindowWidth="1080" />
+                        <wst:AdaptiveTrigger x:Name="DesktopVisualStateTrigger" MinWindowWidth="1080" />
                     </VisualState.StateTriggers>
 
                     <VisualState.Setters>
@@ -347,7 +347,7 @@
 
                 <VisualState x:Name="TabletVisualState">
                     <VisualState.StateTriggers>
-                        <wst:AdaptiveTrigger MinWindowWidth="720" />
+                        <wst:AdaptiveTrigger x:Name="TabletVisualStateTrigger" MinWindowWidth="720" />
                     </VisualState.StateTriggers>
 
                     <VisualState.Setters>
@@ -371,7 +371,7 @@
 
                 <VisualState x:Name="PhoneVisualState">
                     <VisualState.StateTriggers>
-                        <wst:AdaptiveTrigger MinWindowWidth="0" />
+                        <wst:AdaptiveTrigger x:Name="PhoneVisualStateTrigger" MinWindowWidth="0" />
                     </VisualState.StateTriggers>
 
                     <VisualState.Setters>

--- a/src/Neptunium/View/AppShellView.xaml
+++ b/src/Neptunium/View/AppShellView.xaml
@@ -134,14 +134,6 @@
                         </Flyout>
                     </AppBarButton.Flyout>
                 </AppBarButton>
-                <AppBarButton Icon="FourBars" ToolTipService.ToolTip="IoT Remote"
-                              Foreground="{ThemeResource SystemControlForegroundChromeWhiteBrush}">
-                    <AppBarButton.Flyout>
-                        <MenuFlyout>
-                            <MenuFlyoutItem Text="Remote" Command="{Binding GoToRemoteCommand}" />
-                        </MenuFlyout>
-                    </AppBarButton.Flyout>
-                </AppBarButton>
             </StackPanel>
         </Grid>
 

--- a/src/Neptunium/View/AppShellView.xaml
+++ b/src/Neptunium/View/AppShellView.xaml
@@ -247,7 +247,6 @@
               Visibility="Collapsed"
               Background="{ThemeResource SystemControlBackgroundAccentBrush}">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
@@ -258,7 +257,7 @@
                         Background="Transparent" 
                         x:Name="NowPlayingButton" 
                         Height="65"
-                        Width="280"
+                        HorizontalAlignment="Stretch"
                         Margin="0 0 0 0"
                         Click="NowPlayingButton_Click"
                         HorizontalContentAlignment="Stretch">
@@ -304,7 +303,7 @@
                     </Grid>
                 </Button>
             </Grid>
-            <StackPanel Orientation="Horizontal" Grid.Column="2">
+            <StackPanel Orientation="Horizontal" Grid.Column="1">
                 <AppBarButton Icon="Play" Name="PlayButton" Label="Play" Command="{Binding ResumePlaybackCommand, UpdateSourceTrigger=PropertyChanged}" />
             </StackPanel>
         </Grid>

--- a/src/Neptunium/View/AppShellView.xaml
+++ b/src/Neptunium/View/AppShellView.xaml
@@ -41,12 +41,11 @@
                         Grid.Column="0"
                         x:Name="TogglePaneButton"
                         AutomationProperties.Name="Menu"
-                        Checked="TogglePaneButton_Checked"
+                        Click="TogglePaneButton_Click"
                         Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}"
                         Style="{StaticResource SplitViewTogglePaneButtonStyle}"
                         TabIndex="1"
-                        ToolTipService.ToolTip="Menu"
-                        Unchecked="TogglePaneButton_Unchecked" />
+                        ToolTipService.ToolTip="Menu" />
 
                 <TextBlock Name="PageTitleBlock" Grid.Column="1" VerticalAlignment="Center"
                            Style="{ThemeResource BaseTextBlockStyle}" />

--- a/src/Neptunium/View/AppShellView.xaml.cs
+++ b/src/Neptunium/View/AppShellView.xaml.cs
@@ -306,6 +306,18 @@ namespace Neptunium.View
             //FeedbackButton.Visibility = Microsoft.Services.Store.Engagement.StoreServicesFeedbackLauncher.IsSupported() ? Visibility.Visible : Visibility.Collapsed;
         }
 
+        private void TogglePaneButton_Checked(object sender, RoutedEventArgs e)
+        {
+            NepApp.UI.Notifier.VibrateClick();
+            RootSplitView.IsPaneOpen = true;
+        }
+
+        private void TogglePaneButton_Unchecked(object sender, RoutedEventArgs e)
+        {
+            NepApp.UI.Notifier.VibrateClick();
+            RootSplitView.IsPaneOpen = false;
+        }
+
         private void NowPlayingButton_Click(object sender, RoutedEventArgs e)
         {
             NepApp.UI.Notifier.VibrateClick();
@@ -354,12 +366,6 @@ namespace Neptunium.View
         public IEnumerable<string> GetSubscriptions()
         {
             return new string[] { "ShowHandoffFlyout" };
-        }
-
-        private void TogglePaneButton_Click(object sender, RoutedEventArgs e)
-        {
-            NepApp.UI.Notifier.VibrateClick();
-            RootSplitView.IsPaneOpen = !RootSplitView.IsPaneOpen;
         }
     }
 }

--- a/src/Neptunium/View/AppShellView.xaml.cs
+++ b/src/Neptunium/View/AppShellView.xaml.cs
@@ -36,7 +36,7 @@ namespace Neptunium.View
     /// An empty page that can be used on its own or navigated to within a Frame.
     /// </summary>
     [Crystal3.Navigation.NavigationViewModel(typeof(AppShellViewModel),
-        NavigationViewSupportedPlatform.Desktop | NavigationViewSupportedPlatform.Mobile | NavigationViewSupportedPlatform.IoT)]
+        NavigationViewSupportedPlatform.Desktop | NavigationViewSupportedPlatform.Mobile)]
     public sealed partial class AppShellView : Page, Crystal3.Messaging.IMessagingTarget
     {
         private FrameNavigationService inlineNavigationService = null;

--- a/src/Neptunium/View/AppShellView.xaml.cs
+++ b/src/Neptunium/View/AppShellView.xaml.cs
@@ -197,11 +197,10 @@ namespace Neptunium.View
                 Action noChrome = () =>
                 {
                     topAppBar.Visibility = Visibility.Collapsed;
-                    bottomAppBar.Visibility = Visibility.Collapsed;
-
-                    RootSplitView.DisplayMode = SplitViewDisplayMode.Overlay;
+                    bottomAppBar.Visibility = Visibility.Collapsed;        
 
                     RootSplitView.IsPaneOpen = false;
+                    RootSplitView.DisplayMode = SplitViewDisplayMode.Overlay;
 
                     SetMobileStatusBarToTransparent();
 
@@ -215,13 +214,17 @@ namespace Neptunium.View
 
                 noChrome();
 
-                noChromeHandler = new VisualStateChangedEventHandler((o, args) =>
+                noChromeHandler = new VisualStateChangedEventHandler((System.Object o, VisualStateChangedEventArgs args) =>
                 {
                     //this is to "fix" the splitview opening when extending the window in no chrome mode. it doesn't work very well
                     RootSplitView.Visibility = Visibility.Collapsed;
                     noChrome();
                     RootSplitView.Visibility = Visibility.Visible;
                 });
+
+                ShellVisualStateGroup.States.Remove(DesktopVisualState);
+                ShellVisualStateGroup.States.Remove(TabletVisualState);
+                ShellVisualStateGroup.States.Remove(PhoneVisualState);
 
                 ShellVisualStateGroup.CurrentStateChanged += noChromeHandler;
                 ShellVisualStateGroup.CurrentStateChanging += noChromeHandler;
@@ -259,6 +262,15 @@ namespace Neptunium.View
                 {
                     RootGrid.Margin = new Thickness(0);
                 }
+
+                if (!ShellVisualStateGroup.States.Contains(DesktopVisualState))
+                    ShellVisualStateGroup.States.Add(DesktopVisualState);
+
+                if (!ShellVisualStateGroup.States.Contains(TabletVisualState))
+                    ShellVisualStateGroup.States.Add(TabletVisualState);
+
+                if (!ShellVisualStateGroup.States.Contains(PhoneVisualState))
+                    ShellVisualStateGroup.States.Add(PhoneVisualState);
 
                 if (noChromeHandler != null)
                 {

--- a/src/Neptunium/View/AppShellView.xaml.cs
+++ b/src/Neptunium/View/AppShellView.xaml.cs
@@ -296,7 +296,7 @@ namespace Neptunium.View
 
         private void FeedbackButton_Click(object sender, RoutedEventArgs e)
         {
-
+            NepApp.UI.Notifier.VibrateClick();
         }
 
         private void Page_Loaded(object sender, RoutedEventArgs e)
@@ -308,22 +308,28 @@ namespace Neptunium.View
 
         private void TogglePaneButton_Checked(object sender, RoutedEventArgs e)
         {
+            NepApp.UI.Notifier.VibrateClick();
             RootSplitView.IsPaneOpen = true;
         }
 
         private void TogglePaneButton_Unchecked(object sender, RoutedEventArgs e)
         {
+            NepApp.UI.Notifier.VibrateClick();
             RootSplitView.IsPaneOpen = false;
         }
 
         private void NowPlayingButton_Click(object sender, RoutedEventArgs e)
         {
+            NepApp.UI.Notifier.VibrateClick();
+
             //todo make a binding
             inlineNavigationService.SafeNavigateTo<NowPlayingPageViewModel>();
         }
 
         private void RadioButton_Click(object sender, RoutedEventArgs e)
         {
+            NepApp.UI.Notifier.VibrateClick();
+
             //dismiss the menu if its open.
             if (RootSplitView.DisplayMode == SplitViewDisplayMode.Overlay)
                 TogglePaneButton.IsChecked = false;
@@ -334,6 +340,8 @@ namespace Neptunium.View
             var btn = sender as ListItemButton;
 
             if (btn.DataContext == null) return;
+
+            NepApp.UI.Notifier.VibrateClick();
 
             this.GetViewModel<AppShellViewModel>()
                 .HandoffFragment

--- a/src/Neptunium/View/AppShellView.xaml.cs
+++ b/src/Neptunium/View/AppShellView.xaml.cs
@@ -103,6 +103,7 @@ namespace Neptunium.View
             WindowManager.GetWindowServiceForCurrentWindow().SetAppViewBackButtonVisibility(inlineNavigationService.CanGoBackward);
 
             bottomAppBar.Visibility = NepApp.MediaPlayer.IsMediaEngaged ? Visibility.Visible : Visibility.Collapsed;
+            topAppBar.Visibility = Visibility.Visible;
         }
 
         private void Media_IsCastingChanged(object sender, EventArgs e)

--- a/src/Neptunium/View/AppShellView.xaml.cs
+++ b/src/Neptunium/View/AppShellView.xaml.cs
@@ -81,14 +81,11 @@ namespace Neptunium.View
         {
             App.Dispatcher.RunWhenIdleAsync(() =>
             {
-                switch (NepApp.MediaPlayer.IsMediaEngaged)
+                bottomAppBar.Visibility = NepApp.MediaPlayer.IsMediaEngaged ? Visibility.Visible : Visibility.Collapsed;
+
+                if (NepApp.MediaPlayer.IsMediaEngaged)
                 {
-                    case true:
-                        bottomAppBar.Visibility = NepApp.MediaPlayer.IsMediaEngaged ? Visibility.Visible : Visibility.Collapsed;
-                        break;
-                    case false:
-                        bottomAppBar.Visibility = Visibility.Collapsed;
-                        break;
+                    NepApp.SongManager.RefreshMetadata();
                 }
             });
         }

--- a/src/Neptunium/View/AppShellView.xaml.cs
+++ b/src/Neptunium/View/AppShellView.xaml.cs
@@ -185,7 +185,6 @@ namespace Neptunium.View
             }
         }
 
-        private VisualStateChangedEventHandler noChromeHandler = null;
         private void InlineNavigationService_Navigated(object sender, CrystalNavigationEventArgs e)
         {
             WindowManager.GetWindowServiceForCurrentWindow().SetAppViewBackButtonVisibility(inlineNavigationService.CanGoBackward);
@@ -194,40 +193,25 @@ namespace Neptunium.View
             {
                 //no chrome mode
 
-                Action noChrome = () =>
+                topAppBar.Visibility = Visibility.Collapsed;
+                bottomAppBar.Visibility = Visibility.Collapsed;
+
+                RootSplitView.IsPaneOpen = false;
+                RootSplitView.DisplayMode = SplitViewDisplayMode.Overlay;
+
+                SetMobileStatusBarToTransparent();
+
+                CoreApplication.GetCurrentView().TitleBar.ExtendViewIntoTitleBar = true;
+
+                if (CrystalApplication.GetDevicePlatform() == Crystal3.Core.Platform.Mobile)
                 {
-                    topAppBar.Visibility = Visibility.Collapsed;
-                    bottomAppBar.Visibility = Visibility.Collapsed;        
+                    RootGrid.Margin = new Thickness(0, -25, 0, 0);
+                }
 
-                    RootSplitView.IsPaneOpen = false;
-                    RootSplitView.DisplayMode = SplitViewDisplayMode.Overlay;
-
-                    SetMobileStatusBarToTransparent();
-
-                    CoreApplication.GetCurrentView().TitleBar.ExtendViewIntoTitleBar = true;
-
-                    if (CrystalApplication.GetDevicePlatform() == Crystal3.Core.Platform.Mobile)
-                    {
-                        RootGrid.Margin = new Thickness(0, -25, 0, 0);
-                    }
-                };
-
-                noChrome();
-
-                noChromeHandler = new VisualStateChangedEventHandler((System.Object o, VisualStateChangedEventArgs args) =>
-                {
-                    //this is to "fix" the splitview opening when extending the window in no chrome mode. it doesn't work very well
-                    RootSplitView.Visibility = Visibility.Collapsed;
-                    noChrome();
-                    RootSplitView.Visibility = Visibility.Visible;
-                });
 
                 ShellVisualStateGroup.States.Remove(DesktopVisualState);
                 ShellVisualStateGroup.States.Remove(TabletVisualState);
                 ShellVisualStateGroup.States.Remove(PhoneVisualState);
-
-                ShellVisualStateGroup.CurrentStateChanged += noChromeHandler;
-                ShellVisualStateGroup.CurrentStateChanging += noChromeHandler;
 
                 isInNoChromeMode = true;
             }
@@ -271,13 +255,6 @@ namespace Neptunium.View
 
                 if (!ShellVisualStateGroup.States.Contains(PhoneVisualState))
                     ShellVisualStateGroup.States.Add(PhoneVisualState);
-
-                if (noChromeHandler != null)
-                {
-                    ShellVisualStateGroup.CurrentStateChanged -= noChromeHandler;
-                    ShellVisualStateGroup.CurrentStateChanging -= noChromeHandler;
-                    noChromeHandler = null;
-                }
 
                 isInNoChromeMode = false;
             }

--- a/src/Neptunium/View/AppShellView.xaml.cs
+++ b/src/Neptunium/View/AppShellView.xaml.cs
@@ -306,18 +306,6 @@ namespace Neptunium.View
             //FeedbackButton.Visibility = Microsoft.Services.Store.Engagement.StoreServicesFeedbackLauncher.IsSupported() ? Visibility.Visible : Visibility.Collapsed;
         }
 
-        private void TogglePaneButton_Checked(object sender, RoutedEventArgs e)
-        {
-            NepApp.UI.Notifier.VibrateClick();
-            RootSplitView.IsPaneOpen = true;
-        }
-
-        private void TogglePaneButton_Unchecked(object sender, RoutedEventArgs e)
-        {
-            NepApp.UI.Notifier.VibrateClick();
-            RootSplitView.IsPaneOpen = false;
-        }
-
         private void NowPlayingButton_Click(object sender, RoutedEventArgs e)
         {
             NepApp.UI.Notifier.VibrateClick();
@@ -366,6 +354,12 @@ namespace Neptunium.View
         public IEnumerable<string> GetSubscriptions()
         {
             return new string[] { "ShowHandoffFlyout" };
+        }
+
+        private void TogglePaneButton_Click(object sender, RoutedEventArgs e)
+        {
+            NepApp.UI.Notifier.VibrateClick();
+            RootSplitView.IsPaneOpen = !RootSplitView.IsPaneOpen;
         }
     }
 }

--- a/src/Neptunium/View/Dialog/StationInfoDialog.xaml
+++ b/src/Neptunium/View/Dialog/StationInfoDialog.xaml
@@ -6,6 +6,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
+    x:Name="thisPage"
     Loaded="Page_Loaded">
 
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" Padding="5 0">
@@ -37,6 +38,58 @@
             <AppBarButton Label="Website" Icon="Globe" Command="{Binding OpenStationWebsiteCommand}" />
             <AppBarButton Label="Pin" Icon="Pin" x:Name="PinStationButton" Visibility="Visible" Command="{Binding PinStationCommand}" />
         </StackPanel>
+
+        <ListView Grid.Row="2" ItemsSource="{Binding Station.Streams, UpdateSourceTrigger=PropertyChanged}"
+                  ItemClick="ListView_ItemClick"
+                  IsItemClickEnabled="True"
+                  IsFocusEngagementEnabled="True"
+                  SelectionMode="None">
+            <ListView.ItemTemplate>
+                <DataTemplate>
+                    <Grid Width="NaN">
+                        <Grid.RowDefinitions>
+                            <RowDefinition />
+                            <RowDefinition />
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="50" />
+                        </Grid.ColumnDefinitions>
+
+                        <TextBlock Text="{Binding SpecificTitle}" Grid.Row="0"
+                                   Grid.Column="0"
+                                   Style="{ThemeResource CaptionTextBlockStyle}"
+                                   Foreground="{ThemeResource SystemControlForegroundBaseMediumLowBrush}" />
+
+                        <TextBlock Grid.Row="1"
+                                   Grid.Column="0"
+                                   Style="{ThemeResource CaptionTextBlockStyle}"
+                                   Foreground="{ThemeResource SystemControlForegroundBaseLowBrush}">
+                            <Span>
+                                <Run Text="{Binding Bitrate}" />
+                                <Run Text="Kbps" />
+                                <Run Text="·" FontWeight="ExtraBold" />
+                                <Run Text="{Binding ContentType}" />
+                            </Span>
+                        </TextBlock>
+
+                        <Button Grid.Column="1"
+                                Grid.RowSpan="2"
+                                Click="Button_Click"
+                                Background="{ThemeResource AccentButtonBackground}"
+                                CommandParameter="{Binding}">
+                            <SymbolIcon Symbol="Play" />
+                        </Button>
+                        
+                    </Grid>
+                </DataTemplate>
+            </ListView.ItemTemplate>
+            <ListView.ItemContainerStyle>
+                <Style TargetType="ListViewItem">
+                    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                </Style>
+            </ListView.ItemContainerStyle>
+        </ListView>
         
         <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right">
             <StackPanel.Resources>

--- a/src/Neptunium/View/Dialog/StationInfoDialog.xaml
+++ b/src/Neptunium/View/Dialog/StationInfoDialog.xaml
@@ -44,6 +44,11 @@
                   IsItemClickEnabled="True"
                   IsFocusEngagementEnabled="True"
                   SelectionMode="None">
+            <ListView.HeaderTemplate>
+                <DataTemplate>
+                    <TextBlock Text="Available Streams" Style="{ThemeResource BaseTextBlockStyle}" Margin="5, 0" />
+                </DataTemplate>
+            </ListView.HeaderTemplate>
             <ListView.ItemTemplate>
                 <DataTemplate>
                     <Grid Width="NaN">
@@ -59,12 +64,12 @@
                         <TextBlock Text="{Binding SpecificTitle}" Grid.Row="0"
                                    Grid.Column="0"
                                    Style="{ThemeResource CaptionTextBlockStyle}"
-                                   Foreground="{ThemeResource SystemControlForegroundBaseMediumLowBrush}" />
+                                   Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
 
                         <TextBlock Grid.Row="1"
                                    Grid.Column="0"
                                    Style="{ThemeResource CaptionTextBlockStyle}"
-                                   Foreground="{ThemeResource SystemControlForegroundBaseLowBrush}">
+                                   Foreground="{ThemeResource SystemControlForegroundBaseMediumLowBrush}">
                             <Span>
                                 <Run Text="{Binding Bitrate}" />
                                 <Run Text="Kbps" />
@@ -74,13 +79,13 @@
                         </TextBlock>
 
                         <Button Grid.Column="1"
+                                Grid.Row="0"
                                 Grid.RowSpan="2"
                                 Click="Button_Click"
                                 Background="{ThemeResource AccentButtonBackground}"
                                 CommandParameter="{Binding}">
                             <SymbolIcon Symbol="Play" />
                         </Button>
-                        
                     </Grid>
                 </DataTemplate>
             </ListView.ItemTemplate>

--- a/src/Neptunium/View/Dialog/StationInfoDialog.xaml
+++ b/src/Neptunium/View/Dialog/StationInfoDialog.xaml
@@ -11,7 +11,7 @@
 
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" Padding="5 0">
         <Grid.RowDefinitions>
-            <RowDefinition MinHeight="150" Height="Auto" MaxHeight="300" />
+            <RowDefinition MinHeight="150" Height="Auto" MaxHeight="315" />
             <RowDefinition Height="62" />
             <RowDefinition Height="*" />
             <RowDefinition Height="75" />
@@ -19,7 +19,7 @@
 
         <Grid Grid.Row="0" Margin="5,5,5,5">
             <Grid.RowDefinitions>
-                <RowDefinition Height="50" />
+                <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
             <TextBlock Text="{Binding Station.Name, UpdateSourceTrigger=PropertyChanged}" 

--- a/src/Neptunium/View/Dialog/StationInfoDialog.xaml.cs
+++ b/src/Neptunium/View/Dialog/StationInfoDialog.xaml.cs
@@ -1,4 +1,6 @@
 ﻿using Crystal3;
+using Crystal3.UI;
+using Neptunium.ViewModel.Dialog;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -35,6 +37,19 @@ namespace Neptunium.View
 
             //Focus on the cancel button.
             CancelButton.Focus(FocusState.Programmatic);
+        }
+
+        private void ListView_ItemClick(object sender, ItemClickEventArgs e)
+        {
+            var item = e.ClickedItem;
+
+            this.GetViewModel<StationInfoDialogFragment>().PlayStreamCommand.Execute(item);
+        }
+
+        private void Button_Click(object sender, RoutedEventArgs e)
+        {
+            var item = ((Button)sender).DataContext;
+            this.GetViewModel<StationInfoDialogFragment>().PlayStreamCommand.Execute(item);
         }
     }
 }

--- a/src/Neptunium/View/Dialog/StationInfoDialog.xaml.cs
+++ b/src/Neptunium/View/Dialog/StationInfoDialog.xaml.cs
@@ -41,6 +41,7 @@ namespace Neptunium.View
 
         private void ListView_ItemClick(object sender, ItemClickEventArgs e)
         {
+            NepApp.UI.Notifier.VibrateClick();
             var item = e.ClickedItem;
 
             this.GetViewModel<StationInfoDialogFragment>().PlayStreamCommand.Execute(item);
@@ -48,6 +49,7 @@ namespace Neptunium.View
 
         private void Button_Click(object sender, RoutedEventArgs e)
         {
+            //NepApp.UI.Notifier.VibrateClick();
             var item = ((Button)sender).DataContext;
             this.GetViewModel<StationInfoDialogFragment>().PlayStreamCommand.Execute(item);
         }

--- a/src/Neptunium/View/IoTShellView.xaml
+++ b/src/Neptunium/View/IoTShellView.xaml
@@ -1,0 +1,85 @@
+﻿<Page
+    x:Class="Neptunium.View.IoTShellView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Neptunium.View"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:tk="using:WinRTXamlToolkit.Controls"
+    xmlns:uwp="using:Microsoft.Toolkit.Uwp.UI.Controls"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="75*" />
+            <RowDefinition Height="25*" MinHeight="300" />
+        </Grid.RowDefinitions>
+
+
+        <TextBlock Style="{ThemeResource BodyTextBlockStyle}" Text="Connect with a remote to stream something."
+                   x:Name="NothingPlayingTextBlock" Visibility="{Binding , UpdateSourceTrigger=PropertyChanged, Converter={StaticResource InvNullToVisConv}}"
+                   Grid.RowSpan="2" HorizontalAlignment="Center"
+                   VerticalAlignment="Center"/>
+
+        <Grid Grid.Row="0"  x:Name="NowPlayingPanel" 
+              VerticalAlignment="Top"
+              Margin="0 50 0 0"
+              HorizontalAlignment="Center"
+              Visibility="{Binding , UpdateSourceTrigger=PropertyChanged, Converter={StaticResource NullToVisConv}}">
+            <Grid.ColumnDefinitions>
+                    <ColumnDefinition MaxWidth="60" Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+
+                <Grid.ChildrenTransitions>
+                    <TransitionCollection>
+                        <RepositionThemeTransition />
+                    </TransitionCollection>
+                </Grid.ChildrenTransitions>
+
+                <uwp:ImageEx x:Name="NowPlayingImage"
+                            Grid.Column="0"
+                            Visibility="Collapsed"
+                            Height="60"
+                            VerticalAlignment="Top"
+                            Source="{Binding StationLogo, UpdateSourceTrigger=PropertyChanged}"
+                            IsCacheEnabled="True" />
+
+                <Grid Grid.Column="1" Margin="10 -5 10 0" RequestedTheme="Dark">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="50" />
+                        <RowDefinition Height="50" />
+                        <RowDefinition Height="50" />
+                    </Grid.RowDefinitions>
+
+                    <TextBlock Grid.Row="0" Text="{Binding Track, UpdateSourceTrigger=PropertyChanged}"
+                                Style="{ThemeResource HeaderTextBlockStyle}"
+                                Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}"/>
+                    <TextBlock Grid.Row="1" Text="{Binding Artist, UpdateSourceTrigger=PropertyChanged}"
+                                Style="{ThemeResource SubheaderTextBlockStyle}"
+                                Foreground="{ThemeResource SystemControlForegroundBaseMediumHighBrush}"/>
+                    <TextBlock Grid.Row="2"
+                                Style="{ThemeResource CaptionTextBlockStyle}"
+                                Foreground="{ThemeResource SystemControlForegroundBaseMediumLowBrush}">
+                            <Span>
+                                <Run Text="{Binding StationPlayedOn, UpdateSourceTrigger=PropertyChanged}" />
+                                <Run Text="·" />
+                                <Run Text="{Binding RadioProgram, UpdateSourceTrigger=PropertyChanged}" />
+                            </Span>
+                    </TextBlock>
+                </Grid>
+        </Grid>
+
+        <StackPanel Orientation="Horizontal" Grid.Row="1">
+            <Grid Width="400" Visibility="{Binding IsInitialized, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BoolToVisConv}}">
+                <TextBlock>
+                    <Span>
+                        <Run Text="Address:" />
+                        <Run Text="{Binding EndPoint, UpdateSourceTrigger=PropertyChanged}" />
+                    </Span>
+                </TextBlock>
+            </Grid>
+        </StackPanel>
+    </Grid>
+</Page>

--- a/src/Neptunium/View/IoTShellView.xaml
+++ b/src/Neptunium/View/IoTShellView.xaml
@@ -18,7 +18,7 @@
 
 
         <TextBlock Style="{ThemeResource BodyTextBlockStyle}" Text="Connect with a remote to stream something."
-                   x:Name="NothingPlayingTextBlock" Visibility="{Binding , UpdateSourceTrigger=PropertyChanged, Converter={StaticResource InvNullToVisConv}}"
+                   x:Name="NothingPlayingTextBlock" Visibility="{Binding UpdateSourceTrigger=PropertyChanged, Converter={StaticResource InvNullToVisConv}}"
                    Grid.RowSpan="2" HorizontalAlignment="Center"
                    VerticalAlignment="Center"/>
 
@@ -26,7 +26,7 @@
               VerticalAlignment="Top"
               Margin="0 50 0 0"
               HorizontalAlignment="Center"
-              Visibility="{Binding , UpdateSourceTrigger=PropertyChanged, Converter={StaticResource NullToVisConv}}">
+              Visibility="{Binding UpdateSourceTrigger=PropertyChanged, Converter={StaticResource NullToVisConv}}">
             <Grid.ColumnDefinitions>
                     <ColumnDefinition MaxWidth="60" Width="Auto" />
                     <ColumnDefinition Width="*" />
@@ -72,11 +72,11 @@
         </Grid>
 
         <StackPanel Orientation="Horizontal" Grid.Row="1">
-            <Grid Width="400" Visibility="{Binding IsInitialized, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BoolToVisConv}}">
+            <Grid Width="400" x:Name="NetworkPanel" Visibility="{Binding IsInitialized, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BoolToVisConv}}">
                 <TextBlock>
                     <Span>
                         <Run Text="Address:" />
-                        <Run Text="{Binding EndPoint, UpdateSourceTrigger=PropertyChanged}" />
+                        <Run Text="{Binding LocalEndPoint, UpdateSourceTrigger=PropertyChanged}" />
                     </Span>
                 </TextBlock>
             </Grid>

--- a/src/Neptunium/View/IoTShellView.xaml
+++ b/src/Neptunium/View/IoTShellView.xaml
@@ -76,7 +76,7 @@
                 <TextBlock>
                     <Span>
                         <Run Text="Address:" />
-                        <Run Text="{Binding LocalEndPoint, UpdateSourceTrigger=PropertyChanged}" />
+                        <Run Text="{Binding LocalEndPoints, UpdateSourceTrigger=PropertyChanged}" />
                     </Span>
                 </TextBlock>
             </Grid>

--- a/src/Neptunium/View/IoTShellView.xaml
+++ b/src/Neptunium/View/IoTShellView.xaml
@@ -8,27 +8,41 @@
     xmlns:tk="using:WinRTXamlToolkit.Controls"
     xmlns:uwp="using:Microsoft.Toolkit.Uwp.UI.Controls"
     mc:Ignorable="d"
-    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    Background="{ThemeResource SystemControlPageBackgroundChromeLowBrush}">
 
     <Grid>
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="75*" />
             <RowDefinition Height="25*" MinHeight="300" />
         </Grid.RowDefinitions>
 
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="50*" />
+            <ColumnDefinition Width="50*" />
+        </Grid.ColumnDefinitions>
+
 
         <TextBlock Style="{ThemeResource BodyTextBlockStyle}" Text="Connect with a remote to stream something."
                    x:Name="NothingPlayingTextBlock" Visibility="{Binding UpdateSourceTrigger=PropertyChanged, Converter={StaticResource InvNullToVisConv}}"
-                   Grid.RowSpan="2" HorizontalAlignment="Center"
+                   Grid.RowSpan="3" 
+                   Grid.ColumnSpan="2"
+                   HorizontalAlignment="Center"
                    VerticalAlignment="Center"/>
 
-        <Grid Grid.Row="0"  x:Name="NowPlayingPanel" 
+        <TextBlock Text="Neptunium - Now Playing" Style="{ThemeResource TitleTextBlockStyle}"
+                   Foreground="{ThemeResource SystemControlForegroundAccentBrush}"
+                   HorizontalAlignment="Center" 
+                   Grid.ColumnSpan="2"
+                   Margin="0 10"/>
+
+        <Grid Grid.Row="1"  x:Name="NowPlayingPanel" 
               VerticalAlignment="Top"
-              Margin="0 50 0 0"
+              Margin="-0 50 0 0"
               HorizontalAlignment="Center"
               Visibility="{Binding UpdateSourceTrigger=PropertyChanged, Converter={StaticResource NullToVisConv}}">
             <Grid.ColumnDefinitions>
-                    <ColumnDefinition MaxWidth="60" Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
 
@@ -38,15 +52,12 @@
                     </TransitionCollection>
                 </Grid.ChildrenTransitions>
 
-                <uwp:ImageEx x:Name="NowPlayingImage"
-                            Grid.Column="0"
-                            Visibility="Collapsed"
-                            Height="60"
-                            VerticalAlignment="Top"
-                            Source="{Binding StationLogo, UpdateSourceTrigger=PropertyChanged}"
-                            IsCacheEnabled="True" />
+                <Image x:Name="NowPlayingImage"
+                       Grid.Column="0"
+                       Height="200"
+                       VerticalAlignment="Top"/>
 
-                <Grid Grid.Column="1" Margin="10 -5 10 0" RequestedTheme="Dark">
+                <Grid Grid.Column="1" x:Name="NowPlayingInfo" Margin="10 -5 10 0" RequestedTheme="Dark">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="50" />
                         <RowDefinition Height="50" />
@@ -71,15 +82,32 @@
                 </Grid>
         </Grid>
 
-        <StackPanel Orientation="Horizontal" Grid.Row="1">
-            <Grid Width="400" x:Name="NetworkPanel" Visibility="{Binding IsInitialized, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BoolToVisConv}}">
-                <TextBlock>
-                    <Span>
-                        <Run Text="Address:" />
-                        <Run Text="{Binding LocalEndPoints, UpdateSourceTrigger=PropertyChanged}" />
-                    </Span>
-                </TextBlock>
-            </Grid>
-        </StackPanel>
+        <Grid Width="400" x:Name="NetworkPanel" 
+              Grid.Row="2"
+              Grid.Column="0"
+              HorizontalAlignment="Left"
+              Margin="25 0"
+              Visibility="{Binding IsInitialized, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BoolToVisConv}}">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <TextBlock Text="IP Addresses:" Style="{ThemeResource TitleTextBlockStyle}"
+                           Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}"
+                           Grid.Row="0"/>
+            <ItemsControl ItemsSource="{Binding LocalEndPoints, UpdateSourceTrigger=PropertyChanged}"
+                              Foreground="{ThemeResource SystemControlForegroundBaseMediumHighBrush}"
+                              Grid.Row="1"/>
+        </Grid>
+
+        <Grid x:Name="SongHistoryPanel" Grid.Row="1"
+              Grid.RowSpan="2"
+              Grid.Column="1"
+              Visibility="{Binding ElementName=NowPlayingPanel, Path=Visibility, UpdateSourceTrigger=PropertyChanged}">
+            <ListView Header="Song History:"
+                      Margin="20 10"
+                      DisplayMemberPath="Metadata"
+                      x:Name="SongHistoryListView" />
+        </Grid>
     </Grid>
 </Page>

--- a/src/Neptunium/View/IoTShellView.xaml.cs
+++ b/src/Neptunium/View/IoTShellView.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.Toolkit.Uwp.UI.Controls;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -11,6 +12,7 @@ using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Media.Imaging;
 using Windows.UI.Xaml.Navigation;
 
 // The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
@@ -28,9 +30,24 @@ namespace Neptunium.View
             this.InitializeComponent();
 
             NothingPlayingTextBlock.SetBinding(TextBlock.DataContextProperty, NepApp.CreateBinding(NepApp.SongManager, nameof(NepApp.SongManager.CurrentSong)));
-            NowPlayingPanel.SetBinding(Button.DataContextProperty, NepApp.CreateBinding(NepApp.SongManager, nameof(NepApp.SongManager.CurrentSong)));
+            NowPlayingInfo.SetBinding(Button.DataContextProperty, NepApp.CreateBinding(NepApp.SongManager, nameof(NepApp.SongManager.CurrentSong)));
 
             NetworkPanel.SetBinding(Grid.DataContextProperty, new Binding() { Source = NepApp.ServerFrontEnd, UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged });
+
+            NepApp.SongManager.PreSongChanged += SongManager_PreSongChanged;
+        }
+
+        private void SongManager_PreSongChanged(object sender, Media.Songs.NepAppSongChangedEventArgs e)
+        {
+            App.Dispatcher.RunAsync(() =>
+            {
+                if (NepApp.SongManager.CurrentStation != null)
+                {
+                    NowPlayingImage.Source = new BitmapImage(NepApp.SongManager.CurrentStation.StationLogoUrlOnline);
+                }
+
+                SongHistoryListView.DataContext = NepApp.SongManager.History.HistoryOfSongs;
+            });
         }
     }
 }

--- a/src/Neptunium/View/IoTShellView.xaml.cs
+++ b/src/Neptunium/View/IoTShellView.xaml.cs
@@ -31,14 +31,6 @@ namespace Neptunium.View
             NowPlayingPanel.SetBinding(Button.DataContextProperty, NepApp.CreateBinding(NepApp.SongManager, nameof(NepApp.SongManager.CurrentSong)));
 
             NetworkPanel.SetBinding(Grid.DataContextProperty, new Binding() { Source = NepApp.ServerFrontEnd, UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged });
-
-
-            //auto play a station after 5 seconds.
-            System.Threading.Tasks.Task.Delay(5000).ContinueWith(async x =>
-            {
-                var station = await NepApp.Stations.GetStationByNameAsync("AnimeNfo");
-                await NepApp.MediaPlayer.TryStreamStationAsync(station.Streams[0]);
-            });
         }
     }
 }

--- a/src/Neptunium/View/IoTShellView.xaml.cs
+++ b/src/Neptunium/View/IoTShellView.xaml.cs
@@ -30,7 +30,7 @@ namespace Neptunium.View
             NothingPlayingTextBlock.SetBinding(TextBlock.DataContextProperty, NepApp.CreateBinding(NepApp.SongManager, nameof(NepApp.SongManager.CurrentSong)));
             NowPlayingPanel.SetBinding(Button.DataContextProperty, NepApp.CreateBinding(NepApp.SongManager, nameof(NepApp.SongManager.CurrentSong)));
 
-
+            NetworkPanel.SetBinding(Grid.DataContextProperty, new Binding() { Source = NepApp.ServerFrontEnd, UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged });
 
 
             //auto play a station after 5 seconds.

--- a/src/Neptunium/View/IoTShellView.xaml.cs
+++ b/src/Neptunium/View/IoTShellView.xaml.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Neptunium.View
+{
+    /// <summary>
+    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    [Crystal3.Navigation.NavigationViewModel(typeof(Neptunium.ViewModel.AppShellViewModel), Crystal3.Navigation.NavigationViewSupportedPlatform.IoT)]
+    public sealed partial class IoTShellView : Page
+    {
+        public IoTShellView()
+        {
+            this.InitializeComponent();
+
+            NothingPlayingTextBlock.SetBinding(TextBlock.DataContextProperty, NepApp.CreateBinding(NepApp.SongManager, nameof(NepApp.SongManager.CurrentSong)));
+            NowPlayingPanel.SetBinding(Button.DataContextProperty, NepApp.CreateBinding(NepApp.SongManager, nameof(NepApp.SongManager.CurrentSong)));
+
+
+
+
+            //auto play a station after 5 seconds.
+            System.Threading.Tasks.Task.Delay(5000).ContinueWith(async x =>
+            {
+                var station = await NepApp.Stations.GetStationByNameAsync("AnimeNfo");
+                await NepApp.MediaPlayer.TryStreamStationAsync(station.Streams[0]);
+            });
+        }
+    }
+}

--- a/src/Neptunium/View/NowPlayingPage.xaml
+++ b/src/Neptunium/View/NowPlayingPage.xaml
@@ -20,7 +20,7 @@
     
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
         <Grid x:Name="SongInfoPanel"
-              Visibility="{Binding CurrentSong, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource NullToVisConv}}">
+              Visibility="{Binding IsMediaEngaged, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BoolToVisConv}}">
             <Grid.RowDefinitions>
                 <RowDefinition Height="*" />
                 <RowDefinition x:Name="SongInfoRowDef" Height="200" />
@@ -117,7 +117,7 @@
             </StackPanel>
         </Grid>
 
-        <Grid x:Name="NoSongInfoPanel" Visibility="{Binding CurrentSong, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource InvNullToVisConv}}">
+        <Grid x:Name="NoSongInfoPanel" Visibility="{Binding IsMediaEngaged, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource InvBoolToVisConv}}">
             <TextBlock Text="Nothing is playing. Go pick a station to stream!"
                        Style="{ThemeResource BaseTextBlockStyle}" 
                        VerticalAlignment="Center" HorizontalAlignment="Center" />

--- a/src/Neptunium/View/NowPlayingPage.xaml.cs
+++ b/src/Neptunium/View/NowPlayingPage.xaml.cs
@@ -79,9 +79,24 @@ namespace Neptunium.View
             }
         }
 
+        protected override void OnNavigatedTo(NavigationEventArgs e)
+        {
+            if (!Messenger.IsTarget(this))
+            {
+                Messenger.AddTarget(this);
+            }
+
+            base.OnNavigatedTo(e);
+        }
+
         protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)
         {
             NepApp.MediaPlayer.IsPlayingChanged -= Media_IsPlayingChanged;
+
+            if (Messenger.IsTarget(this))
+            {
+                Messenger.RemoveTarget(this);
+            }
 
             base.OnNavigatingFrom(e);
         }

--- a/src/Neptunium/View/ServerRemotePage.xaml
+++ b/src/Neptunium/View/ServerRemotePage.xaml
@@ -10,7 +10,7 @@
 
     <Grid Padding="10">
         <StackPanel>
-            <TextBlock Text="Connect" Style="{ThemeResource HeaderTextBlockStyle}" />
+            <TextBlock Text="Connect" Style="{ThemeResource TitleTextBlockStyle}" />
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
@@ -29,11 +29,18 @@
                               Command="{Binding DisconnectCommand, UpdateSourceTrigger=PropertyChanged}"/>
             </Grid>
 
-            <Grid x:Name="NowPlayingPanel" Visibility="{Binding IsConnected, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BoolToVisConv}}">
-                <!-- todo? maybe?-->
+            <Grid x:Name="NowPlayingPanel" Visibility="{Binding IsConnected, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BoolToVisConv}}" Margin="0 10">
+                <StackPanel DataContext="{Binding CurrentSong, UpdateSourceTrigger=PropertyChanged}">
+                    <TextBlock Text="Now Playing" Style="{ThemeResource TitleTextBlockStyle}" 
+                               Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}"/>
+                    <TextBlock Text="{Binding Track, UpdateSourceTrigger=PropertyChanged}" Style="{ThemeResource BaseTextBlockStyle}" 
+                               Foreground="{ThemeResource SystemControlForegroundBaseMediumHighBrush}"/>
+                    <TextBlock Text="{Binding Artist, UpdateSourceTrigger=PropertyChanged}" Style="{ThemeResource BodyTextBlockStyle}" 
+                               Foreground="{ThemeResource SystemControlForegroundBaseMediumLowBrush}" />
+                </StackPanel>
             </Grid>
 
-            <Grid Visibility="{Binding IsConnected, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BoolToVisConv}}">
+            <Grid Visibility="{Binding IsConnected, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BoolToVisConv}}" Margin="0 10">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="200" />
                     <ColumnDefinition Width="50" />

--- a/src/Neptunium/View/ServerRemotePage.xaml
+++ b/src/Neptunium/View/ServerRemotePage.xaml
@@ -18,18 +18,26 @@
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
 
-                <TextBox Grid.Column="0" x:Name="AddressTextBox" Height="25" />
-                <AppBarButton Grid.Column="1" x:Name="ConnectButton" Icon="Add" Content="Connect" Command="{Binding ConnectCommand}"
+                <TextBox Grid.Column="0" x:Name="AddressTextBox" Height="25"
+                         IsEnabled="{Binding IsConnected, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource InvBoolToVisConv}}"/>
+                <AppBarButton Grid.Column="1" x:Name="ConnectButton" Icon="Add" Content="Connect" 
+                              IsEnabled="{Binding IsConnected, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource InvBoolToVisConv}}"
+                              Command="{Binding ConnectCommand, UpdateSourceTrigger=PropertyChanged}"
                         CommandParameter="{Binding ElementName=AddressTextBox, Path=Text}"/>
-                <AppBarButton Grid.Column="2" x:Name="DisconnectButton" Icon="Delete" Content="Disconnect" Command="{Binding DisconnectCommand}"/>
+                <AppBarButton Grid.Column="2" x:Name="DisconnectButton" Icon="Delete" Content="Disconnect"
+                              IsEnabled="{Binding IsConnected, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BoolToVisConv}}"
+                              Command="{Binding DisconnectCommand, UpdateSourceTrigger=PropertyChanged}"/>
             </Grid>
 
             <Grid x:Name="NowPlayingPanel" Visibility="{Binding IsConnected, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BoolToVisConv}}">
                 <!-- todo? maybe?-->
             </Grid>
 
-            <ListBox x:Name="StationsList" Visibility="{Binding IsConnected, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BoolToVisConv}}"
-                     ItemsSource="{Binding Stations, UpdateSourceTrigger=PropertyChanged}" DisplayMemberPath="Name" />
+            <ScrollViewer>
+                <ListView Header="Pick a station" x:Name="StationsList" 
+                      Visibility="{Binding IsConnected, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BoolToVisConv}}"
+                      ItemsSource="{Binding SortedAvailableStations, UpdateSourceTrigger=PropertyChanged}" DisplayMemberPath="Name" />
+            </ScrollViewer>
         </StackPanel>
     </Grid>
 </Page>

--- a/src/Neptunium/View/ServerRemotePage.xaml
+++ b/src/Neptunium/View/ServerRemotePage.xaml
@@ -33,11 +33,28 @@
                 <!-- todo? maybe?-->
             </Grid>
 
-            <ScrollViewer>
-                <ListView Header="Pick a station" x:Name="StationsList" 
-                      Visibility="{Binding IsConnected, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BoolToVisConv}}"
-                      ItemsSource="{Binding SortedAvailableStations, UpdateSourceTrigger=PropertyChanged}" DisplayMemberPath="Name" />
-            </ScrollViewer>
+            <Grid Visibility="{Binding IsConnected, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BoolToVisConv}}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="200" />
+                    <ColumnDefinition Width="50" />
+                    <ColumnDefinition Width="50" />
+                </Grid.ColumnDefinitions>
+                
+                <ComboBox Header="Pick a station" x:Name="StationsList"
+                          Grid.Column="0"
+                          SelectedIndex="0"
+                          HorizontalAlignment="Stretch"
+                          Margin="0 0 10 0"
+                          HorizontalContentAlignment="Stretch"
+                          ItemsSource="{Binding SortedAvailableStations, UpdateSourceTrigger=PropertyChanged}" DisplayMemberPath="Name" />
+                <Button Grid.Column="1" VerticalAlignment="Bottom" Command="{Binding SendStationCommand}"
+                        CommandParameter="{Binding ElementName=StationsList,Path=SelectedItem, UpdateSourceTrigger=PropertyChanged}">
+                    <SymbolIcon Symbol="Send" />
+                </Button>
+                <Button Grid.Column="2" VerticalAlignment="Bottom" Command="{Binding SendStopCommand}">
+                    <SymbolIcon Symbol="Stop" />
+                </Button>
+            </Grid>
         </StackPanel>
     </Grid>
 </Page>

--- a/src/Neptunium/View/ServerRemotePage.xaml
+++ b/src/Neptunium/View/ServerRemotePage.xaml
@@ -47,10 +47,9 @@
                     <ColumnDefinition Width="50" />
                     <ColumnDefinition Width="50" />
                 </Grid.ColumnDefinitions>
-                
+
                 <ComboBox Header="Pick a station" x:Name="StationsList"
                           Grid.Column="0"
-                          SelectedIndex="0"
                           HorizontalAlignment="Stretch"
                           Margin="0 0 10 0"
                           HorizontalContentAlignment="Stretch"

--- a/src/Neptunium/View/ServerRemotePage.xaml
+++ b/src/Neptunium/View/ServerRemotePage.xaml
@@ -1,0 +1,33 @@
+﻿<Page
+    x:Class="Neptunium.View.ServerRemotePage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Neptunium.View"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+        <StackPanel>
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <TextBox Grid.Column="0" x:Name="AddressTextBox" />
+                <AppBarButton Grid.Column="1" x:Name="ConnectButton" Icon="Add" Content="Connect" Command="{Binding ConnectCommand}"
+                        CommandParameter="{Binding ElementName=AddressTextBox, Path=Text}"/>
+                <AppBarButton Grid.Column="2" x:Name="DisconnectButton" Icon="Delete" Content="Disconnect" Command="{Binding DisconnectCommand}" />
+            </Grid>
+
+            <Grid x:Name="NowPlayingPanel">
+                <!-- todo? maybe?-->
+            </Grid>
+
+            <ListBox x:Name="StationsList" ItemsSource="{Binding Stations, UpdateSourceTrigger=PropertyChanged}" DisplayMemberPath="Name" />
+        </StackPanel>
+    </Grid>
+</Page>

--- a/src/Neptunium/View/ServerRemotePage.xaml
+++ b/src/Neptunium/View/ServerRemotePage.xaml
@@ -8,8 +8,9 @@
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-    <Grid>
+    <Grid Padding="10">
         <StackPanel>
+            <TextBlock Text="Connect" Style="{ThemeResource HeaderTextBlockStyle}" />
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
@@ -17,17 +18,18 @@
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
 
-                <TextBox Grid.Column="0" x:Name="AddressTextBox" />
+                <TextBox Grid.Column="0" x:Name="AddressTextBox" Height="25" />
                 <AppBarButton Grid.Column="1" x:Name="ConnectButton" Icon="Add" Content="Connect" Command="{Binding ConnectCommand}"
                         CommandParameter="{Binding ElementName=AddressTextBox, Path=Text}"/>
-                <AppBarButton Grid.Column="2" x:Name="DisconnectButton" Icon="Delete" Content="Disconnect" Command="{Binding DisconnectCommand}" />
+                <AppBarButton Grid.Column="2" x:Name="DisconnectButton" Icon="Delete" Content="Disconnect" Command="{Binding DisconnectCommand}"/>
             </Grid>
 
-            <Grid x:Name="NowPlayingPanel">
+            <Grid x:Name="NowPlayingPanel" Visibility="{Binding IsConnected, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BoolToVisConv}}">
                 <!-- todo? maybe?-->
             </Grid>
 
-            <ListBox x:Name="StationsList" ItemsSource="{Binding Stations, UpdateSourceTrigger=PropertyChanged}" DisplayMemberPath="Name" />
+            <ListBox x:Name="StationsList" Visibility="{Binding IsConnected, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BoolToVisConv}}"
+                     ItemsSource="{Binding Stations, UpdateSourceTrigger=PropertyChanged}" DisplayMemberPath="Name" />
         </StackPanel>
     </Grid>
 </Page>

--- a/src/Neptunium/View/ServerRemotePage.xaml
+++ b/src/Neptunium/View/ServerRemotePage.xaml
@@ -19,13 +19,13 @@
                 </Grid.ColumnDefinitions>
 
                 <TextBox Grid.Column="0" x:Name="AddressTextBox" Height="25"
-                         IsEnabled="{Binding IsConnected, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource InvBoolToVisConv}}"/>
+                         Visibility="{Binding IsConnected, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource InvBoolToVisConv}}"/>
                 <AppBarButton Grid.Column="1" x:Name="ConnectButton" Icon="Add" Content="Connect" 
-                              IsEnabled="{Binding IsConnected, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource InvBoolToVisConv}}"
+                              Visibility="{Binding IsConnected, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource InvBoolToVisConv}}"
                               Command="{Binding ConnectCommand, UpdateSourceTrigger=PropertyChanged}"
                         CommandParameter="{Binding ElementName=AddressTextBox, Path=Text}"/>
                 <AppBarButton Grid.Column="2" x:Name="DisconnectButton" Icon="Delete" Content="Disconnect"
-                              IsEnabled="{Binding IsConnected, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BoolToVisConv}}"
+                              Visibility="{Binding IsConnected, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BoolToVisConv}}"
                               Command="{Binding DisconnectCommand, UpdateSourceTrigger=PropertyChanged}"/>
             </Grid>
 

--- a/src/Neptunium/View/ServerRemotePage.xaml
+++ b/src/Neptunium/View/ServerRemotePage.xaml
@@ -19,6 +19,7 @@
                 </Grid.ColumnDefinitions>
 
                 <TextBox Grid.Column="0" x:Name="AddressTextBox" Height="25"
+                         PlaceholderText="Enter the IP address to the Neptunium server."
                          Visibility="{Binding IsConnected, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource InvBoolToVisConv}}"/>
                 <AppBarButton Grid.Column="1" x:Name="ConnectButton" Icon="Add" Content="Connect" 
                               Visibility="{Binding IsConnected, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource InvBoolToVisConv}}"

--- a/src/Neptunium/View/ServerRemotePage.xaml.cs
+++ b/src/Neptunium/View/ServerRemotePage.xaml.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Neptunium.View
+{
+    /// <summary>
+    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    [Crystal3.Navigation.NavigationViewModel(typeof(Neptunium.ViewModel.ServerRemotePageViewModel), 
+        Crystal3.Navigation.NavigationViewSupportedPlatform.Desktop | Crystal3.Navigation.NavigationViewSupportedPlatform.Mobile)]
+    public sealed partial class ServerRemotePage : Page
+    {
+        public ServerRemotePage()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/Neptunium/View/ServerShellView.xaml
+++ b/src/Neptunium/View/ServerShellView.xaml
@@ -1,5 +1,5 @@
 ﻿<Page
-    x:Class="Neptunium.View.IoTShellView"
+    x:Class="Neptunium.View.ServerShellView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Neptunium.View"

--- a/src/Neptunium/View/ServerShellView.xaml.cs
+++ b/src/Neptunium/View/ServerShellView.xaml.cs
@@ -22,10 +22,10 @@ namespace Neptunium.View
     /// <summary>
     /// An empty page that can be used on its own or navigated to within a Frame.
     /// </summary>
-    [Crystal3.Navigation.NavigationViewModel(typeof(Neptunium.ViewModel.AppShellViewModel), Crystal3.Navigation.NavigationViewSupportedPlatform.IoT)]
-    public sealed partial class IoTShellView : Page
+    [Crystal3.Navigation.NavigationViewModel(typeof(Neptunium.ViewModel.Server.ServerShellViewModel), Crystal3.Navigation.NavigationViewSupportedPlatform.IoT)]
+    public sealed partial class ServerShellView : Page
     {
-        public IoTShellView()
+        public ServerShellView()
         {
             this.InitializeComponent();
 

--- a/src/Neptunium/View/SettingsPage.xaml
+++ b/src/Neptunium/View/SettingsPage.xaml
@@ -31,16 +31,26 @@
                                Text="Notifications"/>
                         <ToggleSwitch Header="Show song change notifications"
                                       x:Name="SongNotificationSwitch"
-                                      XYFocusDown="{Binding ElementName=MetadataSwitch}"
+                                      XYFocusDown="{Binding ElementName=HapticFeedbackSwitch}"
                                       IsOn="{Binding ShowSongNotification, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
-                        
+
+                        <MenuFlyoutSeparator />
+
+                        <TextBlock Style="{StaticResource GroupHeaderTextBlockStyle}"
+                               Text="UI"/>
+
+                        <ToggleSwitch Header="Use haptic feedback" 
+                                      x:Name="HapticFeedbackSwitch"
+                                      XYFocusUp="{Binding ElementName=SongNotificationSwitch}"
+                                      IsOn="{Binding UseHapticFeedback, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
+
                         <MenuFlyoutSeparator />
                         
                         <TextBlock Style="{StaticResource GroupHeaderTextBlockStyle}"
                                Text="Metadata"/>
                         <ToggleSwitch Header="Find song metadata when song changes" 
                                       x:Name="MetadataSwitch"
-                                      XYFocusUp="{Binding ElementName=SongNotificationSwitch}"
+                                      XYFocusUp="{Binding ElementName=HapticFeedbackSwitch}"
                                       IsOn="{Binding FindSongMetadata, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
                         <ToggleSwitch Header="Update LockScreen with artwork when available."
                                   x:Name="UpdateLockScreenSwitch"
@@ -126,6 +136,7 @@
                     <VisualState.Setters>
                         <Setter Target="RootPivot.Margin" Value="48 0 48 0" />
                         <Setter Target="RootPivot.(Pivot.IsHeaderItemsCarouselEnabled)" Value="False" />
+                        <Setter Target="HapticFeedbackSwitch.IsEnabled" Value="False" />
                     </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="TabletOrHigherVisualState">
@@ -142,6 +153,7 @@
 
                     <VisualState.Setters>
                         <Setter Target="RootPivot.(Pivot.IsHeaderItemsCarouselEnabled)" Value="False" />
+                        <Setter Target="HapticFeedbackSwitch.IsEnabled" Value="False" />
                     </VisualState.Setters>
                 </VisualState>
 
@@ -152,6 +164,7 @@
 
                     <VisualState.Setters>
                         <Setter Target="RootPivot.(Pivot.IsHeaderItemsCarouselEnabled)" Value="True" />
+                        <Setter Target="HapticFeedbackSwitch.IsEnabled" Value="True" />
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>

--- a/src/Neptunium/View/SettingsPage.xaml
+++ b/src/Neptunium/View/SettingsPage.xaml
@@ -34,7 +34,7 @@
                                       XYFocusDown="{Binding ElementName=HeadphonesAnnounceSongsSwitch}"
                                       IsOn="{Binding ShowSongNotification, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
 
-                        <ToggleSwitch Header="Announce song when the song playing changes when headphones are connected."
+                        <ToggleSwitch Header="Announce song when the song playing&#x0a;changes when headphones are connected."
                                       x:Name="HeadphonesAnnounceSongsSwitch"
                                       XYFocusUp="{Binding ElementName=SongNotificationSwitch}"
                                       XYFocusDown="{Binding ElementName=HapticFeedbackSwitch}"
@@ -120,7 +120,7 @@
                     <TextBlock Style="{StaticResource GroupHeaderTextBlockStyle}"
                                Text="Options" />
 
-                    <ToggleSwitch Header="Announce song when the song playing changes when connected to Bluetooth."
+                    <ToggleSwitch Header="Announce song when the song playing&#x0a;changes when connected to Bluetooth."
                                   IsOn="{Binding SaySongNotificationsInBluetoothMode, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"/>
                 </StackPanel>
             </PivotItem>

--- a/src/Neptunium/View/SettingsPage.xaml
+++ b/src/Neptunium/View/SettingsPage.xaml
@@ -31,33 +31,16 @@
                                Text="Notifications"/>
                         <ToggleSwitch Header="Show song change notifications"
                                       x:Name="SongNotificationSwitch"
-                                      XYFocusDown="{Binding ElementName=ConserveDataSwitch}"
+                                      XYFocusDown="{Binding ElementName=MetadataSwitch}"
                                       IsOn="{Binding ShowSongNotification, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
                         
-                        <MenuFlyoutSeparator />
-                        
-                        <TextBlock Style="{StaticResource GroupHeaderTextBlockStyle}"
-                               Text="Data"/>
-                        <ToggleSwitch Header="Conserve data on metered connections."
-                                      x:Name="ConserveDataSwitch"
-                                      XYFocusUp="{Binding ElementName=SongNotificationSwitch}"
-                                      XYFocusDown="{Binding ElementName=ChooseBitrateSwitch}"
-                                      IsOn="{Binding ConserveData, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
-
-                        <ToggleSwitch Header="Automatically choose appropriate&#10;bitrate based on connection." 
-                                      x:Name="ChooseBitrateSwitch"
-                                      XYFocusUp="{Binding ElementName=ConserveDataSwitch}"
-                                      XYFocusDown="{Binding ElementName=MetadataSwitch}"
-                                      IsEnabled="{Binding ElementName=ConserveDataSwitch, Path=IsOn, UpdateSourceTrigger=PropertyChanged}"
-                                      IsOn="{Binding ChooseBitrate, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
-
                         <MenuFlyoutSeparator />
                         
                         <TextBlock Style="{StaticResource GroupHeaderTextBlockStyle}"
                                Text="Metadata"/>
                         <ToggleSwitch Header="Find song metadata when song changes" 
                                       x:Name="MetadataSwitch"
-                                      XYFocusUp="{Binding ElementName=ChooseBitrateSwitch}"
+                                      XYFocusUp="{Binding ElementName=SongNotificationSwitch}"
                                       IsOn="{Binding FindSongMetadata, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
                         <ToggleSwitch Header="Update LockScreen with artwork when available."
                                   x:Name="UpdateLockScreenSwitch"
@@ -72,6 +55,26 @@
 
                             <Button Content="Set Fallback Lockscreen" x:Name="SetFallBackLockScreenBtn" Click="SetFallBackLockScreenBtn_Click" />
                         </StackPanel>
+                    </StackPanel>
+                </ScrollViewer>
+            </PivotItem>
+            <PivotItem Header="Network">
+                <ScrollViewer>
+                    <StackPanel Margin="10 0">
+                        <TextBlock Style="{StaticResource GroupHeaderTextBlockStyle}"
+                               Text="Data"/>
+                        <ToggleSwitch Header="Conserve data on metered connections."
+                                      x:Name="ConserveDataSwitch"
+                                      XYFocusDown="{Binding ElementName=ChooseBitrateSwitch}"
+                                      IsOn="{Binding ConserveData, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
+
+                        <ToggleSwitch Header="Automatically choose appropriate&#10;bitrate based on connection." 
+                                      x:Name="ChooseBitrateSwitch"
+                                      XYFocusUp="{Binding ElementName=ConserveDataSwitch}"
+                                      IsEnabled="{Binding ElementName=ConserveDataSwitch, Path=IsOn, UpdateSourceTrigger=PropertyChanged}"
+                                      IsOn="{Binding ChooseBitrate, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
+
+                        <!--<MenuFlyoutSeparator />-->
                     </StackPanel>
                 </ScrollViewer>
             </PivotItem>

--- a/src/Neptunium/View/SettingsPage.xaml
+++ b/src/Neptunium/View/SettingsPage.xaml
@@ -106,6 +106,15 @@
                                   IsOn="{Binding SaySongNotifications, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"/>
                 </StackPanel>
             </PivotItem>
+            <PivotItem Header="Experimental">
+                <StackPanel Margin="10 0">
+                    <TextBlock Style="{StaticResource GroupHeaderTextBlockStyle}"
+                               Text="Miscellaneous"/>
+                    <ToggleSwitch Header="Show Remote menu"
+                                      x:Name="ShowRemoteSwitch"
+                                      IsOn="{Binding ShowRemote, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
+                </StackPanel>
+            </PivotItem>
         </Pivot>
 
         <VisualStateManager.VisualStateGroups>

--- a/src/Neptunium/View/SettingsPage.xaml
+++ b/src/Neptunium/View/SettingsPage.xaml
@@ -31,8 +31,14 @@
                                Text="Notifications"/>
                         <ToggleSwitch Header="Show song change notifications"
                                       x:Name="SongNotificationSwitch"
-                                      XYFocusDown="{Binding ElementName=HapticFeedbackSwitch}"
+                                      XYFocusDown="{Binding ElementName=HeadphonesAnnounceSongsSwitch}"
                                       IsOn="{Binding ShowSongNotification, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
+
+                        <ToggleSwitch Header="Announce song when the song playing changes when headphones are connected."
+                                      x:Name="HeadphonesAnnounceSongsSwitch"
+                                      XYFocusUp="{Binding ElementName=SongNotificationSwitch}"
+                                      XYFocusDown="{Binding ElementName=HapticFeedbackSwitch}"
+                                      IsOn="{Binding SaySongNotificationsWhenHeadphonesConnected, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"/>
 
                         <MenuFlyoutSeparator />
 
@@ -41,7 +47,8 @@
 
                         <ToggleSwitch Header="Use haptic feedback" 
                                       x:Name="HapticFeedbackSwitch"
-                                      XYFocusUp="{Binding ElementName=SongNotificationSwitch}"
+                                      XYFocusUp="{Binding ElementName=HeadphonesAnnounceSongsSwitch}"
+                                      XYFocusDown="{Binding ElementName=MetadataSwitch}"
                                       IsOn="{Binding UseHapticFeedback, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
 
                         <MenuFlyoutSeparator />
@@ -107,13 +114,14 @@
                         <Button x:Name="SelectBluetoothButton" Click="SelectBluetoothButton_Click" Content="Select Device" />
                         <Button Content="Clear Device" Margin="5 0" Command="{Binding ClearBluetoothDeviceCommand}" />
                     </StackPanel>
+                    
                     <MenuFlyoutSeparator />
 
                     <TextBlock Style="{StaticResource GroupHeaderTextBlockStyle}"
                                Text="Options" />
 
-                    <ToggleSwitch Header="Announce song when the song playing changes."
-                                  IsOn="{Binding SaySongNotifications, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"/>
+                    <ToggleSwitch Header="Announce song when the song playing changes when connected to Bluetooth."
+                                  IsOn="{Binding SaySongNotificationsInBluetoothMode, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"/>
                 </StackPanel>
             </PivotItem>
             <PivotItem Header="Experimental">

--- a/src/Neptunium/View/SettingsPage.xaml
+++ b/src/Neptunium/View/SettingsPage.xaml
@@ -44,7 +44,7 @@
                                       XYFocusDown="{Binding ElementName=ChooseBitrateSwitch}"
                                       IsOn="{Binding ConserveData, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
 
-                        <ToggleSwitch Header="Automatically choose appropriate bitrate based on connection." 
+                        <ToggleSwitch Header="Automatically choose appropriate&#10;bitrate based on connection." 
                                       x:Name="ChooseBitrateSwitch"
                                       XYFocusUp="{Binding ElementName=ConserveDataSwitch}"
                                       XYFocusDown="{Binding ElementName=MetadataSwitch}"

--- a/src/Neptunium/View/SettingsPage.xaml
+++ b/src/Neptunium/View/SettingsPage.xaml
@@ -31,14 +31,33 @@
                                Text="Notifications"/>
                         <ToggleSwitch Header="Show song change notifications"
                                       x:Name="SongNotificationSwitch"
-                                      XYFocusDown="{Binding ElementName=MetadataSwitch}"
+                                      XYFocusDown="{Binding ElementName=ConserveDataSwitch}"
                                       IsOn="{Binding ShowSongNotification, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
+                        
                         <MenuFlyoutSeparator />
+                        
+                        <TextBlock Style="{StaticResource GroupHeaderTextBlockStyle}"
+                               Text="Data"/>
+                        <ToggleSwitch Header="Conserve data on metered connections."
+                                      x:Name="ConserveDataSwitch"
+                                      XYFocusUp="{Binding ElementName=SongNotificationSwitch}"
+                                      XYFocusDown="{Binding ElementName=ChooseBitrateSwitch}"
+                                      IsOn="{Binding ConserveData, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
+
+                        <ToggleSwitch Header="Automatically choose appropriate bitrate based on connection." 
+                                      x:Name="ChooseBitrateSwitch"
+                                      XYFocusUp="{Binding ElementName=ConserveDataSwitch}"
+                                      XYFocusDown="{Binding ElementName=MetadataSwitch}"
+                                      IsEnabled="{Binding ElementName=ConserveDataSwitch, Path=IsOn, UpdateSourceTrigger=PropertyChanged}"
+                                      IsOn="{Binding ChooseBitrate, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
+
+                        <MenuFlyoutSeparator />
+                        
                         <TextBlock Style="{StaticResource GroupHeaderTextBlockStyle}"
                                Text="Metadata"/>
                         <ToggleSwitch Header="Find song metadata when song changes" 
                                       x:Name="MetadataSwitch"
-                                      XYFocusUp="{Binding ElementName=SongNotificationSwitch}"
+                                      XYFocusUp="{Binding ElementName=ChooseBitrateSwitch}"
                                       IsOn="{Binding FindSongMetadata, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
                         <ToggleSwitch Header="Update LockScreen with artwork when available"
                                   x:Name="UpdateLockScreenSwitch"

--- a/src/Neptunium/View/SettingsPage.xaml
+++ b/src/Neptunium/View/SettingsPage.xaml
@@ -59,7 +59,7 @@
                                       x:Name="MetadataSwitch"
                                       XYFocusUp="{Binding ElementName=ChooseBitrateSwitch}"
                                       IsOn="{Binding FindSongMetadata, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
-                        <ToggleSwitch Header="Update LockScreen with artwork when available"
+                        <ToggleSwitch Header="Update LockScreen with artwork when available."
                                   x:Name="UpdateLockScreenSwitch"
                                   Visibility="Collapsed"
                                   IsOn="{Binding UpdateLockScreenWithSongArt, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />

--- a/src/Neptunium/View/SettingsPage.xaml
+++ b/src/Neptunium/View/SettingsPage.xaml
@@ -23,7 +23,7 @@
     </Page.Resources>
 
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
-        <Pivot x:Name="RootPivot" Pivot.IsHeaderItemsCarouselEnabled="False">
+        <Pivot x:Name="RootPivot" Pivot.IsHeaderItemsCarouselEnabled="True">
             <PivotItem Header="General">
                 <ScrollViewer>
                     <StackPanel Margin="10 0">

--- a/src/Neptunium/View/SettingsPage.xaml.cs
+++ b/src/Neptunium/View/SettingsPage.xaml.cs
@@ -56,6 +56,8 @@ namespace Neptunium.View
             {
                 //force focus on Xbox.
                 RootPivot.Focus(FocusState.Keyboard);
+
+                RootPivot.Items.Remove(bluetoothPivot);
             }
         }
 

--- a/src/Neptunium/View/SongHistoryPage.xaml
+++ b/src/Neptunium/View/SongHistoryPage.xaml
@@ -68,26 +68,29 @@
 
                         <Grid Grid.Column="1" Margin="15 0" VerticalAlignment="Center">
                             <Grid.RowDefinitions>
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition Height="*" />
+                                <RowDefinition Height="30" />
+                                <RowDefinition Height="20" />
+                                <RowDefinition Height="30" />
                             </Grid.RowDefinitions>
 
-                            <TextBlock Text="{Binding Metadata.Track}" Grid.Row="0" 
-                                       Style="{ThemeResource BaseTextBlockStyle}"
-                                       x:Name="TrackTextBlock"
+
+                            <TextBlock Style="{ThemeResource BaseTextBlockStyle}"
+                                       Text="{Binding Metadata.Track}"
                                        Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}"
-                                       VerticalAlignment="Bottom"/>
-                            <TextBlock Grid.Row="1"
-                                       VerticalAlignment="Top"
-                                       x:Name="ArtistTextBlock"
+                                       TextTrimming="WordEllipsis"
+                                       HorizontalAlignment="Left"
+                                       ToolTipService.ToolTip="{Binding Metadata.Track}"
+                                       VerticalAlignment="Bottom"
+                                       Grid.Row="0" />  
+
+                            <TextBlock Style="{ThemeResource BodyTextBlockStyle}"
                                        Foreground="{ThemeResource SystemControlForegroundBaseMediumHighBrush}"
-                                       Style="{ThemeResource BodyTextBlockStyle}">
-                            <Span>
-                                <Run Text="{Binding Metadata.Artist}" />
-                                <Run Text="·" FontWeight="ExtraBold" />
-                                <Run Text="{Binding Metadata.StationPlayedOn}" />
-                            </Span>
-                            </TextBlock>
+                                       Grid.Row="1"
+                                       Text="{Binding Metadata.Artist}" />
+
+                            <TextBlock Style="{ThemeResource CaptionTextBlockStyle}"
+                                       Foreground="{ThemeResource SystemControlForegroundAccentBrush}"
+                                       Grid.Row="2" Text="{Binding Metadata.StationPlayedOn}"  />
                         </Grid>
                     </Grid>
                     <wrt:ListItemButton.ContextFlyout>

--- a/src/Neptunium/View/StationProgramsPage.xaml
+++ b/src/Neptunium/View/StationProgramsPage.xaml
@@ -170,6 +170,10 @@
             </ListView.GroupStyle>
         </ListView>
 
+
+        <ProgressRing Height="60" Width="60" VerticalAlignment="Center" HorizontalAlignment="Center"
+                      IsActive="{Binding IsBusy, UpdateSourceTrigger=PropertyChanged}" />
+
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup>
                 <VisualState x:Name="XboxVisualState">

--- a/src/Neptunium/View/StationProgramsPage.xaml
+++ b/src/Neptunium/View/StationProgramsPage.xaml
@@ -61,6 +61,7 @@
                            Grid.Column="1"
                            TextTrimming="WordEllipsis"
                            MaxWidth="200"
+                           HorizontalAlignment="Left"
                            ToolTipService.ToolTip="{Binding Program.Name}"
                            VerticalAlignment="Bottom"
                            Grid.Row="0" />
@@ -90,6 +91,37 @@
 
             </Grid>
         </DataTemplate>
+
+        <DataTemplate x:Key="ModileScheduleListItemTemplate">
+            <Grid Margin="0 0 0 5" Padding="10 0">
+
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="30" />
+                    <RowDefinition Height="20" />
+                    <RowDefinition Height="30" />
+                </Grid.RowDefinitions>
+
+
+                <TextBlock Style="{ThemeResource BaseTextBlockStyle}"
+                           Text="{Binding Program.Name}"
+                           Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}"
+                           TextTrimming="WordEllipsis"
+                           HorizontalAlignment="Left"
+                           ToolTipService.ToolTip="{Binding Program.Name}"
+                           VerticalAlignment="Bottom"
+                           Grid.Row="0" />
+
+                <TextBlock Style="{ThemeResource BodyTextBlockStyle}"
+                           Foreground="{ThemeResource SystemControlForegroundBaseMediumHighBrush}"
+                           Grid.Row="1"
+                           Text="{Binding TimeLocal, Converter={StaticResource StripDateFromDateTimeConverter}}" />
+
+                <TextBlock Style="{ThemeResource CaptionTextBlockStyle}"
+                           Foreground="{ThemeResource SystemControlForegroundAccentBrush}"
+                           Grid.Row="2" Text="{Binding Station.Name}"  />
+
+            </Grid>
+        </DataTemplate>
         <Style x:Key="ScheduleListStyle" TargetType="ListView">
             <Setter Property="Background" Value="Transparent" />
             <Setter Property="ItemContainerStyle">
@@ -105,7 +137,7 @@
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
         <ListView x:Name="ScheduleListView"
                   ItemsSource="{Binding SortedScheduleItems.View, UpdateSourceTrigger=PropertyChanged}"
-                  ItemTemplate="{StaticResource ScheduleListItemTemplate}"
+                  ItemTemplate="{StaticResource ModileScheduleListItemTemplate}"
                   Style="{StaticResource ScheduleListStyle}">
             <ListView.GroupStyle>
                 <GroupStyle>
@@ -125,7 +157,7 @@
                         <wst:DeviceFamilyStateTrigger DeviceFamily="Xbox" />
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
-
+                        <Setter Target="ScheduleListView.ItemTemplate" Value="{StaticResource ScheduleListItemTemplate}" />
                     </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="TabletOrHigherVisualState">
@@ -142,7 +174,7 @@
                     </VisualState.StateTriggers>
 
                     <VisualState.Setters>
-                        
+                        <Setter Target="ScheduleListView.ItemTemplate" Value="{StaticResource ScheduleListItemTemplate}" />
                     </VisualState.Setters>
                 </VisualState>
 
@@ -152,7 +184,7 @@
                     </VisualState.StateTriggers>
 
                     <VisualState.Setters>
-                        
+                        <Setter Target="ScheduleListView.ItemTemplate" Value="{StaticResource ModileScheduleListItemTemplate}" />
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>

--- a/src/Neptunium/View/StationProgramsPage.xaml
+++ b/src/Neptunium/View/StationProgramsPage.xaml
@@ -16,157 +16,107 @@
     <Page.Resources>
         <nui:StripDateFromDateTimeConverter x:Key="StripDateFromDateTimeConverter" />
         <cconv:InverseCollectionNullOrEmptyToVisibilityConverter x:Key="CollEmptyConv" />
-    </Page.Resources>
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
-        <Pivot x:Name="RootPivot" Pivot.IsHeaderItemsCarouselEnabled="False">
-            <Pivot.Resources>
-                <DataTemplate x:Key="NoProgramsScheduledTemplate">
-                    <TextBlock Text="It doesn't look like we have any station programming scheduled on this day of the week."
+        <DataTemplate x:Key="NoProgramsScheduledTemplate">
+            <TextBlock Text="It doesn't look like we have any station programming scheduled on this day of the week."
                                Style="{ThemeResource BaseTextBlockStyle}" />
-                </DataTemplate>
+        </DataTemplate>
 
-                <Style TargetType="ContentControl" x:Key="NoProgramsScheduledContentControlStyle">
-                    <Setter Property="ContentTemplate" Value="{StaticResource NoProgramsScheduledTemplate}" />
-                    <Setter Property="HorizontalAlignment" Value="Center" />
-                    <Setter Property="VerticalAlignment" Value="Center" />
-                </Style>
+        <Style TargetType="ContentControl" x:Key="NoProgramsScheduledContentControlStyle">
+            <Setter Property="ContentTemplate" Value="{StaticResource NoProgramsScheduledTemplate}" />
+            <Setter Property="HorizontalAlignment" Value="Center" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+        </Style>
 
-                <DataTemplate x:Key="ScheduleListItemTemplate">
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="100" />
-                            <ColumnDefinition Width="Auto" MaxWidth="250" />
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="200" />
-                        </Grid.ColumnDefinitions>
+        <DataTemplate x:Key="ScheduleListItemTemplate">
+            <Grid Margin="0 0 0 5" Padding="10 0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="60" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="200" />
+                </Grid.ColumnDefinitions>
 
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="30" />
-                            <RowDefinition Height="30" />
-                        </Grid.RowDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="30" />
+                    <RowDefinition Height="30" />
+                </Grid.RowDefinitions>
 
-                        <uwp:ImageEx Grid.Column="0"
+                <uwp:ImageEx Grid.Column="0"
                                      Grid.Row="0"
                                      Grid.RowSpan="2"
                                      Stretch="Fill"
-                                     Width="75"
-                                     Height="75"
-                                     Margin="-10"
-                                     VerticalAlignment="Top"
+                                     Width="45"
+                                     Height="45"
+                                     VerticalAlignment="Center"
                                      IsCacheEnabled="True">
-                            <uwp:ImageEx.Source>
-                                <BitmapImage UriSource="{Binding Station.StationLogoUrl, Mode=OneTime}" />
-                            </uwp:ImageEx.Source>
-                        </uwp:ImageEx>
+                    <uwp:ImageEx.Source>
+                        <BitmapImage UriSource="{Binding Station.StationLogoUrl, Mode=OneTime}" />
+                    </uwp:ImageEx.Source>
+                </uwp:ImageEx>
 
 
-                        <TextBlock Style="{ThemeResource BaseTextBlockStyle}"
-                                   Text="{Binding Program.Name}"
-                                   Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}"
-                                   Grid.Column="1"
-                                   VerticalAlignment="Bottom"
-                                   Grid.Row="0" />
+                <TextBlock Style="{ThemeResource BaseTextBlockStyle}"
+                           Text="{Binding Program.Name}"
+                           Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}"
+                           Grid.Column="1"
+                           TextTrimming="WordEllipsis"
+                           MaxWidth="200"
+                           ToolTipService.ToolTip="{Binding Program.Name}"
+                           VerticalAlignment="Bottom"
+                           Grid.Row="0" />
 
-                        <TextBlock Style="{ThemeResource BodyTextBlockStyle}"
+                <TextBlock Style="{ThemeResource BodyTextBlockStyle}"
                                    Text="{Binding Station.Name}"
                                    Foreground="{ThemeResource SystemControlForegroundBaseMediumHighBrush}"
                                    Grid.Column="1"
                                    Grid.Row="1" />
 
-                        <TextBlock Style="{ThemeResource BaseTextBlockStyle}"
-                                   Text="{Binding Day}"
-                                   Foreground="{ThemeResource SystemControlForegroundBaseMediumLowBrush}"
-                                   Grid.Column="3"
-                                   VerticalAlignment="Bottom"
-                                   HorizontalAlignment="Right"
-                                   Grid.Row="0" />
+                <TextBlock Style="{ThemeResource BaseTextBlockStyle}"
+                           Text="{Binding Day}"
+                           Foreground="{ThemeResource SystemControlForegroundBaseMediumLowBrush}"
+                           Grid.Column="2"
+                           VerticalAlignment="Bottom"
+                           HorizontalAlignment="Right"
+                           Margin="0 0 15 0"
+                           Grid.Row="0" />
 
-                        <TextBlock Style="{ThemeResource BodyTextBlockStyle}"
-                                   Text="{Binding TimeLocal, Converter={StaticResource StripDateFromDateTimeConverter}}"
-                                   Foreground="{ThemeResource SystemControlForegroundBaseLowBrush}"
-                                   Grid.Column="3"
-                                   HorizontalAlignment="Right"
-                                   Grid.Row="1" />
+                <TextBlock Style="{ThemeResource BodyTextBlockStyle}"
+                           Text="{Binding TimeLocal, Converter={StaticResource StripDateFromDateTimeConverter}}"
+                           Foreground="{ThemeResource SystemControlForegroundBaseLowBrush}"
+                           Grid.Column="2"
+                           HorizontalAlignment="Right"
+                           Margin="0 0 15 0"
+                           Grid.Row="1" />
 
-                    </Grid>
-                </DataTemplate>
-                <Style x:Key="ScheduleListStyle" TargetType="ListBox">
-                    <Setter Property="ItemTemplate" Value="{StaticResource ScheduleListItemTemplate}" />
-                    <Setter Property="Background" Value="Transparent" />
-                    <Setter Property="ItemContainerStyle">
-                        <Setter.Value>
-                            <Style TargetType="ListBoxItem">
-                                <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-                            </Style>
-                        </Setter.Value>
-                    </Setter>
-                </Style>
-            </Pivot.Resources>
-            <PivotItem Header="Sunday" x:Name="SundayPivotItem">
-                <Grid>
-                    <ListBox ItemsSource="{Binding SundayItems, UpdateSourceTrigger=PropertyChanged}"
-                         Style="{StaticResource ScheduleListStyle}" />
+            </Grid>
+        </DataTemplate>
+        <Style x:Key="ScheduleListStyle" TargetType="ListView">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="ItemContainerStyle">
+                <Setter.Value>
+                    <Style TargetType="ListViewItem">
+                        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                    </Style>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </Page.Resources>
 
-                    <ContentControl Style="{StaticResource NoProgramsScheduledContentControlStyle}"
-                                    Visibility="{Binding SundayItems, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource CollEmptyConv}}" />
-                </Grid>
-            </PivotItem>
-            <PivotItem Header="Monday">
-                <Grid>
-                    <ListBox ItemsSource="{Binding MondayItems, UpdateSourceTrigger=PropertyChanged}"
-                         Style="{StaticResource ScheduleListStyle}" />
-
-                    <ContentControl Style="{StaticResource NoProgramsScheduledContentControlStyle}"
-                                    Visibility="{Binding MondayItems, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource CollEmptyConv}}" />
-                </Grid>
-            </PivotItem>
-            <PivotItem Header="Tuesday">
-                <Grid>
-                    <ListBox ItemsSource="{Binding TuesdayItems, UpdateSourceTrigger=PropertyChanged}"
-                         Style="{StaticResource ScheduleListStyle}" />
-
-                    <ContentControl Style="{StaticResource NoProgramsScheduledContentControlStyle}"
-                                    Visibility="{Binding TuesdayItems, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource CollEmptyConv}}" />
-                </Grid>
-            </PivotItem>
-            <PivotItem Header="Wednesday">
-                <Grid>
-                    <ListBox ItemsSource="{Binding WednesdayItems, UpdateSourceTrigger=PropertyChanged}"
-                         Style="{StaticResource ScheduleListStyle}" />
-
-                    <ContentControl Style="{StaticResource NoProgramsScheduledContentControlStyle}"
-                                    Visibility="{Binding WednesdayItems, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource CollEmptyConv}}" />
-                </Grid>
-            </PivotItem>
-            <PivotItem Header="Thursday">
-                <Grid>
-                    <ListBox ItemsSource="{Binding ThursdayItems, UpdateSourceTrigger=PropertyChanged}"
-                         Style="{StaticResource ScheduleListStyle}" />
-
-                    <ContentControl Style="{StaticResource NoProgramsScheduledContentControlStyle}"
-                                    Visibility="{Binding ThursdayItems, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource CollEmptyConv}}" />
-                </Grid>
-            </PivotItem>
-            <PivotItem Header="Friday">
-                <Grid>
-                    <ListBox ItemsSource="{Binding FridayItems, UpdateSourceTrigger=PropertyChanged}"
-                         Style="{StaticResource ScheduleListStyle}" />
-
-                    <ContentControl Style="{StaticResource NoProgramsScheduledContentControlStyle}"
-                                    Visibility="{Binding FridayItems, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource CollEmptyConv}}" />
-                </Grid>
-            </PivotItem>
-            <PivotItem Header="Saturday">
-                <Grid>
-                    <ListBox ItemsSource="{Binding SaturdayItems, UpdateSourceTrigger=PropertyChanged}"
-                         Style="{StaticResource ScheduleListStyle}" />
-
-                    <ContentControl Style="{StaticResource NoProgramsScheduledContentControlStyle}"
-                                    Visibility="{Binding SaturdayItems, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource CollEmptyConv}}" />
-                </Grid>
-            </PivotItem>
-        </Pivot>
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+        <ListView x:Name="ScheduleListView"
+                  ItemsSource="{Binding SortedScheduleItems.View, UpdateSourceTrigger=PropertyChanged}"
+                  ItemTemplate="{StaticResource ScheduleListItemTemplate}"
+                  Style="{StaticResource ScheduleListStyle}">
+            <ListView.GroupStyle>
+                <GroupStyle>
+                    <GroupStyle.HeaderTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Key}" Style="{ThemeResource BaseTextBlockStyle}"/>
+                        </DataTemplate>
+                    </GroupStyle.HeaderTemplate>
+                </GroupStyle>
+            </ListView.GroupStyle>
+        </ListView>
 
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup>
@@ -175,8 +125,7 @@
                         <wst:DeviceFamilyStateTrigger DeviceFamily="Xbox" />
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
-                        <Setter Target="RootPivot.Margin" Value="48 0 48 0" />
-                        <Setter Target="RootPivot.(Pivot.IsHeaderItemsCarouselEnabled)" Value="False" />
+
                     </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="TabletOrHigherVisualState">
@@ -193,7 +142,7 @@
                     </VisualState.StateTriggers>
 
                     <VisualState.Setters>
-                        <Setter Target="RootPivot.(Pivot.IsHeaderItemsCarouselEnabled)" Value="False" />
+                        
                     </VisualState.Setters>
                 </VisualState>
 
@@ -203,7 +152,7 @@
                     </VisualState.StateTriggers>
 
                     <VisualState.Setters>
-                        <Setter Target="RootPivot.(Pivot.IsHeaderItemsCarouselEnabled)" Value="True" />
+                        
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>

--- a/src/Neptunium/View/StationProgramsPage.xaml
+++ b/src/Neptunium/View/StationProgramsPage.xaml
@@ -94,13 +94,29 @@
 
         <DataTemplate x:Key="ModileScheduleListItemTemplate">
             <Grid Margin="0 0 0 5" Padding="10 0">
-
                 <Grid.RowDefinitions>
                     <RowDefinition Height="30" />
                     <RowDefinition Height="20" />
                     <RowDefinition Height="30" />
                 </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="62" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
 
+                <uwp:ImageEx Grid.Column="0"
+                            Grid.Row="0"
+                            Grid.RowSpan="3"
+                            Stretch="Fill"
+                            Width="45"
+                            Height="45"
+                            VerticalAlignment="Center"
+                            Margin="0 -5 0 0"
+                            IsCacheEnabled="True">
+                    <uwp:ImageEx.Source>
+                        <BitmapImage UriSource="{Binding Station.StationLogoUrl, Mode=OneTime}" />
+                    </uwp:ImageEx.Source>
+                </uwp:ImageEx>
 
                 <TextBlock Style="{ThemeResource BaseTextBlockStyle}"
                            Text="{Binding Program.Name}"
@@ -109,16 +125,20 @@
                            HorizontalAlignment="Left"
                            ToolTipService.ToolTip="{Binding Program.Name}"
                            VerticalAlignment="Bottom"
-                           Grid.Row="0" />
+                           Grid.Row="0"
+                           Grid.Column="1"/>
 
                 <TextBlock Style="{ThemeResource BodyTextBlockStyle}"
                            Foreground="{ThemeResource SystemControlForegroundBaseMediumHighBrush}"
                            Grid.Row="1"
+                           Grid.Column="1"
                            Text="{Binding TimeLocal, Converter={StaticResource StripDateFromDateTimeConverter}}" />
 
                 <TextBlock Style="{ThemeResource CaptionTextBlockStyle}"
                            Foreground="{ThemeResource SystemControlForegroundAccentBrush}"
-                           Grid.Row="2" Text="{Binding Station.Name}"  />
+                           Grid.Row="2" 
+                           Grid.Column="1"
+                           Text="{Binding Station.Name}"  />
 
             </Grid>
         </DataTemplate>

--- a/src/Neptunium/View/StationProgramsPage.xaml.cs
+++ b/src/Neptunium/View/StationProgramsPage.xaml.cs
@@ -35,7 +35,7 @@ namespace Neptunium.View
             if (CrystalApplication.GetDevicePlatform() == Crystal3.Core.Platform.Xbox)
             {
                 //force focus on Xbox.
-                RootPivot.Focus(FocusState.Keyboard);
+                ScheduleListView.Focus(FocusState.Keyboard);
             }
         }
     }

--- a/src/Neptunium/View/StationsPage.xaml
+++ b/src/Neptunium/View/StationsPage.xaml
@@ -64,9 +64,10 @@
                                             Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}"
                                             VerticalAlignment="Bottom"/>
                             <TextBlock Grid.Row="1"
-                                            VerticalAlignment="Top"
-                                            Foreground="{ThemeResource SystemControlForegroundBaseMediumHighBrush}"
-                                            Style="{ThemeResource BodyTextBlockStyle}">
+                                       VerticalAlignment="Top"
+                                       Foreground="{ThemeResource SystemControlForegroundBaseMediumHighBrush}"
+                                       Style="{ThemeResource BodyTextBlockStyle}"
+                                       TextWrapping="WrapWholeWords">
                                         <Span>
                                             <Run Text="{Binding LastPlayedStationDescription, UpdateSourceTrigger=PropertyChanged}" />
                                         </Span>

--- a/src/Neptunium/View/StationsPage.xaml
+++ b/src/Neptunium/View/StationsPage.xaml
@@ -23,7 +23,7 @@
             </Grid.RowDefinitions>
 
             <StackPanel Grid.Row="0"
-                        Margin="0 0 0 0"
+                        Margin="0 10 0 10"
                         Orientation="Vertical"
                         x:Name="LastPlayedPanel"
                         LayoutUpdated="LastPlayedPanel_LayoutUpdated"

--- a/src/Neptunium/View/StationsPage.xaml
+++ b/src/Neptunium/View/StationsPage.xaml
@@ -18,22 +18,23 @@
     <ScrollViewer>
         <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
             <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
+                <RowDefinition x:Name="LastPlayedPanelRowDef" Height="Auto" />
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
 
             <StackPanel Grid.Row="0"
-                        Height="Auto"
-                        Margin="0 0 0 10"
+                        Margin="0 0 0 0"
                         Orientation="Vertical"
+                        x:Name="LastPlayedPanel"
+                        LayoutUpdated="LastPlayedPanel_LayoutUpdated"
                         Visibility="{Binding LastPlayedStation, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource NullToVisConv}}">
 
                 <TextBlock Style="{ThemeResource TitleTextBlockStyle}"
-                           Margin="5 0"
-                           Text="Last Played:" />
+                           Margin="10 0"
+                           Text="Last Played" />
 
                 <StackPanel Orientation="Horizontal">
-                    <AppBarButton Icon="Play" Label="Play" />
+                    <AppBarButton Icon="Play" Label="Play" Command="{Binding PlayLastPlayedStationCommand}" />
                     <Grid Height="80" VerticalAlignment="Center">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="75" />

--- a/src/Neptunium/View/StationsPage.xaml
+++ b/src/Neptunium/View/StationsPage.xaml
@@ -15,146 +15,223 @@
         <!--<CollectionViewSource x:Key="GroupedStationItems" IsSourceGrouped="True" Source="{Binding GroupedStations, UpdateSourceTrigger=PropertyChanged}" />-->
     </Page.Resources>
 
-    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
-        <ListView ItemsSource="{Binding AvailableStations, UpdateSourceTrigger=PropertyChanged}"
-                  SelectionMode="Single"
-                  Margin="5"
-                  x:Name="stationsListView"
-                  Visibility="Visible"
-                  IsItemClickEnabled="True">
-            <ListView.ItemContainerStyle>
-                <Style TargetType="ListViewItem">
-                    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-                </Style>
-            </ListView.ItemContainerStyle>
-            <ListView.ItemTemplate>
-                <DataTemplate>
-                    <wrt:ListItemButton Command="{Binding ElementName=thisPage, Path=DataContext.ShowStationInfoCommand}"
-                                        CommandParameter="{Binding}">
-                        <Grid Height="80" VerticalAlignment="Center">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="75" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
+    <ScrollViewer>
+        <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
 
-                            <uwp:ImageEx Grid.Column="0"
-                                     Stretch="Fill"
-                                     Width="75"
-                                     Height="75"
-                                     Margin="0 5 0 0"
-                                     VerticalAlignment="Top"
-                                     IsCacheEnabled="True">
-                                <uwp:ImageEx.Source>
-                                    <BitmapImage UriSource="{Binding StationLogoUrl, Mode=OneTime}" />
-                                </uwp:ImageEx.Source>
-                            </uwp:ImageEx>
+            <StackPanel Grid.Row="0"
+                        Height="Auto"
+                        Margin="0 0 0 10"
+                        Orientation="Vertical"
+                        Visibility="{Binding LastPlayedStation, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource NullToVisConv}}">
 
-                            <Grid Grid.Column="1" Margin="15 0" VerticalAlignment="Center">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="*" />
-                                </Grid.RowDefinitions>
+                <TextBlock Style="{ThemeResource TitleTextBlockStyle}"
+                           Margin="5 0"
+                           Text="Last Played:" />
 
-                                <TextBlock Text="{Binding Name, Mode=OneTime}" Grid.Row="0" 
-                                        Style="{ThemeResource BaseTextBlockStyle}"
-                                        Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}"
-                                        VerticalAlignment="Bottom"/>
-                                <TextBlock Grid.Row="1"
-                                        VerticalAlignment="Top"
-                                        Foreground="{ThemeResource SystemControlForegroundBaseMediumHighBrush}"
-                                        Style="{ThemeResource BodyTextBlockStyle}">
-                                    <Span>
-                                        <Run Text="{Binding Genres[0], Mode=OneTime}" />
-                                        <Run Text="·" FontWeight="ExtraBold" />
-                                        <Run Text="{Binding Group, TargetNullValue='Independent', Mode=OneTime}" />
-                                    </Span>
-                                </TextBlock>
-                            </Grid>
-                        </Grid>
+                <StackPanel Orientation="Horizontal">
+                    <AppBarButton Icon="Play" Label="Play" />
+                    <Grid Height="80" VerticalAlignment="Center">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="75" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
 
-                        <wrt:ListItemButton.ContextFlyout>
-                            <MenuFlyout>
-                                <MenuFlyoutItem Text="Pin"
-                                                Command="{Binding ElementName=thisPage, Path=DataContext.PinStationCommand}"
-                                                CommandParameter="{Binding}"/>
-                                <MenuFlyoutSeparator />
-                                <MenuFlyoutItem Text="Website"
-                                                Command="{Binding ElementName=thisPage, Path=DataContext.OpenStationWebsiteCommand}"
-                                                CommandParameter="{Binding}" />
-                            </MenuFlyout>
-                        </wrt:ListItemButton.ContextFlyout>
-                    </wrt:ListItemButton>
-                </DataTemplate>
-            </ListView.ItemTemplate>
-        </ListView>
-        <GridView ItemsSource="{Binding AvailableStations, UpdateSourceTrigger=PropertyChanged}"
-                  SelectionMode="Single"
-                  Margin="5"
-                  x:Name="stationsGridView"
-                  Visibility="Collapsed"
-                  IsItemClickEnabled="True">
-            <!--<GridView.GroupStyle>
-                <GroupStyle>
-                    <GroupStyle.HeaderTemplate>
-                        <DataTemplate>
-                            <TextBlock Text="{Binding Key}"/>
-                        </DataTemplate>
-                    </GroupStyle.HeaderTemplate>
-                </GroupStyle>
-            </GridView.GroupStyle>-->
-            <GridView.ItemTemplate>
-                <DataTemplate>
-                    <wrt:ListItemButton Command="{Binding ElementName=thisPage, Path=DataContext.ShowStationInfoCommand}"
-                                        CommandParameter="{Binding}" Margin="5">
-                        <Grid Width="125" Height="200">
+                        <uwp:ImageEx Grid.Column="0"
+                                         Stretch="Fill"
+                                         Width="75"
+                                         Height="75"
+                                         Margin="0 5 0 0"
+                                         VerticalAlignment="Top"
+                                         IsCacheEnabled="True">
+                            <uwp:ImageEx.Source>
+                                <BitmapImage UriSource="{Binding LastPlayedStationLogoUrl, UpdateSourceTrigger=PropertyChanged}" />
+                            </uwp:ImageEx.Source>
+                        </uwp:ImageEx>
+
+                        <Grid Grid.Column="1" Margin="15 0" VerticalAlignment="Center">
                             <Grid.RowDefinitions>
-                                <RowDefinition Height="125" />
-                                <RowDefinition MaxHeight="35" Height="Auto" />
-                                <RowDefinition Height="25" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="*" />
                             </Grid.RowDefinitions>
 
-                            <uwp:ImageEx Height="125" Width="125" Grid.Row="0" Stretch="Fill" VerticalAlignment="Top" IsCacheEnabled="True">
-                                <uwp:ImageEx.Source>
-                                    <BitmapImage UriSource="{Binding StationLogoUrl, Mode=OneTime}" />
-                                </uwp:ImageEx.Source>
-                            </uwp:ImageEx>
-
-                            <TextBlock TextAlignment="Left"
-                                       Grid.Row="1" TextWrapping="WrapWholeWords"
-                                       Text="{Binding Name, Mode=OneTime}"
-                                       MaxLines="2"
-                                       Style="{ThemeResource BaseTextBlockStyle}"
-                                       Margin="5 0"
-                                       Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}" />
-
-                            <TextBlock Grid.Row="2" Text="{Binding Genres[0], Mode=OneTime}"
-                                       Style="{ThemeResource BodyTextBlockStyle}"
-                                       Margin="5 0"
-                                       Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
-
-                            <ToolTipService.ToolTip>
-                                <TextBlock Text="{Binding Description, Mode=OneTime}" />
-                            </ToolTipService.ToolTip>
+                            <TextBlock Text="{Binding LastPlayedStation, UpdateSourceTrigger=PropertyChanged}" Grid.Row="0" 
+                                            Style="{ThemeResource BaseTextBlockStyle}"
+                                            Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}"
+                                            VerticalAlignment="Bottom"/>
+                            <TextBlock Grid.Row="1"
+                                            VerticalAlignment="Top"
+                                            Foreground="{ThemeResource SystemControlForegroundBaseMediumHighBrush}"
+                                            Style="{ThemeResource BodyTextBlockStyle}">
+                                        <Span>
+                                            <Run Text="{Binding LastPlayedStationDescription, UpdateSourceTrigger=PropertyChanged}" />
+                                        </Span>
+                            </TextBlock>
                         </Grid>
-                        <wrt:ListItemButton.ContextFlyout>
-                            <MenuFlyout>
-                                <MenuFlyoutItem Text="Pin"
-                                                Command="{Binding ElementName=thisPage, Path=DataContext.PinStationCommand}"
-                                                CommandParameter="{Binding}"/>
-                                <MenuFlyoutSeparator />
-                                <MenuFlyoutItem Text="Website"
-                                                Command="{Binding ElementName=thisPage, Path=DataContext.OpenStationWebsiteCommand}"
-                                                CommandParameter="{Binding}" />
-                            </MenuFlyout>
-                        </wrt:ListItemButton.ContextFlyout>
-                    </wrt:ListItemButton>
-                </DataTemplate>
-            </GridView.ItemTemplate>
-        </GridView>
+                    </Grid>
+                </StackPanel>
+            </StackPanel>
 
-        <ProgressRing Height="60" Width="60" VerticalAlignment="Center" HorizontalAlignment="Center"
-                      IsActive="{Binding IsBusy, UpdateSourceTrigger=PropertyChanged}" />
+            <ListView ItemsSource="{Binding AvailableStations, UpdateSourceTrigger=PropertyChanged}"
+                      SelectionMode="Single"
+                      Margin="5"
+                      x:Name="stationsListView"
+                      Visibility="Visible"
+                      IsItemClickEnabled="True"
+                      Grid.Row="1">
+                <ListView.HeaderTemplate>
+                    <DataTemplate>
+                        <TextBlock Text="Station Library"
+                                   Margin="5 0"
+                                   Style="{ThemeResource TitleTextBlockStyle}" />
+                    </DataTemplate>
+                </ListView.HeaderTemplate>
+                <ListView.ItemContainerStyle>
+                    <Style TargetType="ListViewItem">
+                        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                    </Style>
+                </ListView.ItemContainerStyle>
+                <ListView.ItemTemplate>
+                    <DataTemplate>
+                        <wrt:ListItemButton Command="{Binding ElementName=thisPage, Path=DataContext.ShowStationInfoCommand}"
+                                            CommandParameter="{Binding}">
+                            <Grid Height="80" VerticalAlignment="Center">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="75" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
 
+                                <uwp:ImageEx Grid.Column="0"
+                                         Stretch="Fill"
+                                         Width="75"
+                                         Height="75"
+                                         Margin="0 5 0 0"
+                                         VerticalAlignment="Top"
+                                         IsCacheEnabled="True">
+                                    <uwp:ImageEx.Source>
+                                        <BitmapImage UriSource="{Binding StationLogoUrl, Mode=OneTime}" />
+                                    </uwp:ImageEx.Source>
+                                </uwp:ImageEx>
+
+                                <Grid Grid.Column="1" Margin="15 0" VerticalAlignment="Center">
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="*" />
+                                    </Grid.RowDefinitions>
+
+                                    <TextBlock Text="{Binding Name, Mode=OneTime}" Grid.Row="0" 
+                                            Style="{ThemeResource BaseTextBlockStyle}"
+                                            Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}"
+                                            VerticalAlignment="Bottom"/>
+                                    <TextBlock Grid.Row="1"
+                                            VerticalAlignment="Top"
+                                            Foreground="{ThemeResource SystemControlForegroundBaseMediumHighBrush}"
+                                            Style="{ThemeResource BodyTextBlockStyle}">
+                                        <Span>
+                                            <Run Text="{Binding Genres[0], Mode=OneTime}" />
+                                            <Run Text="·" FontWeight="ExtraBold" />
+                                            <Run Text="{Binding Group, TargetNullValue='Independent', Mode=OneTime}" />
+                                        </Span>
+                                    </TextBlock>
+                                </Grid>
+                            </Grid>
+
+                            <wrt:ListItemButton.ContextFlyout>
+                                <MenuFlyout>
+                                    <MenuFlyoutItem Text="Pin"
+                                                    Command="{Binding ElementName=thisPage, Path=DataContext.PinStationCommand}"
+                                                    CommandParameter="{Binding}"/>
+                                    <MenuFlyoutSeparator />
+                                    <MenuFlyoutItem Text="Website"
+                                                    Command="{Binding ElementName=thisPage, Path=DataContext.OpenStationWebsiteCommand}"
+                                                    CommandParameter="{Binding}" />
+                                </MenuFlyout>
+                            </wrt:ListItemButton.ContextFlyout>
+                        </wrt:ListItemButton>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
+            <GridView ItemsSource="{Binding AvailableStations, UpdateSourceTrigger=PropertyChanged}"
+                      SelectionMode="Single"
+                      Margin="5"
+                      x:Name="stationsGridView"
+                      Visibility="Collapsed"
+                      IsItemClickEnabled="True"
+                      Grid.Row="1">
+                <GridView.HeaderTemplate>
+                    <DataTemplate>
+                        <TextBlock Text="Station Library"
+                                   Margin="5 0"
+                                   Style="{ThemeResource TitleTextBlockStyle}" />
+                    </DataTemplate>
+                </GridView.HeaderTemplate>
+                <!--<GridView.GroupStyle>
+                    <GroupStyle>
+                        <GroupStyle.HeaderTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding Key}"/>
+                            </DataTemplate>
+                        </GroupStyle.HeaderTemplate>
+                    </GroupStyle>
+                </GridView.GroupStyle>-->
+                <GridView.ItemTemplate>
+                    <DataTemplate>
+                        <wrt:ListItemButton Command="{Binding ElementName=thisPage, Path=DataContext.ShowStationInfoCommand}"
+                                            CommandParameter="{Binding}" Margin="5">
+                            <Grid Width="125" Height="200">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="125" />
+                                    <RowDefinition MaxHeight="35" Height="Auto" />
+                                    <RowDefinition Height="25" />
+                                </Grid.RowDefinitions>
+
+                                <uwp:ImageEx Height="125" Width="125" Grid.Row="0" Stretch="Fill" VerticalAlignment="Top" IsCacheEnabled="True">
+                                    <uwp:ImageEx.Source>
+                                        <BitmapImage UriSource="{Binding StationLogoUrl, Mode=OneTime}" />
+                                    </uwp:ImageEx.Source>
+                                </uwp:ImageEx>
+
+                                <TextBlock TextAlignment="Left"
+                                           Grid.Row="1" TextWrapping="WrapWholeWords"
+                                           Text="{Binding Name, Mode=OneTime}"
+                                           MaxLines="2"
+                                           Style="{ThemeResource BaseTextBlockStyle}"
+                                           Margin="5 0"
+                                           Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}" />
+
+                                <TextBlock Grid.Row="2" Text="{Binding Genres[0], Mode=OneTime}"
+                                           Style="{ThemeResource BodyTextBlockStyle}"
+                                           Margin="5 0"
+                                           Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
+
+                                <ToolTipService.ToolTip>
+                                    <TextBlock Text="{Binding Description, Mode=OneTime}" />
+                                </ToolTipService.ToolTip>
+                            </Grid>
+                            <wrt:ListItemButton.ContextFlyout>
+                                <MenuFlyout>
+                                    <MenuFlyoutItem Text="Pin"
+                                                    Command="{Binding ElementName=thisPage, Path=DataContext.PinStationCommand}"
+                                                    CommandParameter="{Binding}"/>
+                                    <MenuFlyoutSeparator />
+                                    <MenuFlyoutItem Text="Website"
+                                                    Command="{Binding ElementName=thisPage, Path=DataContext.OpenStationWebsiteCommand}"
+                                                    CommandParameter="{Binding}" />
+                                </MenuFlyout>
+                            </wrt:ListItemButton.ContextFlyout>
+                        </wrt:ListItemButton>
+                    </DataTemplate>
+                </GridView.ItemTemplate>
+            </GridView>
+
+            <ProgressRing Height="60" Width="60" VerticalAlignment="Center" HorizontalAlignment="Center"
+                          IsActive="{Binding IsBusy, UpdateSourceTrigger=PropertyChanged}" />
+
+            
+        </Grid>
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup>
                 <VisualState x:Name="DesktopVisualState">
@@ -191,5 +268,5 @@
                 </VisualState>
             </VisualStateGroup>
         </VisualStateManager.VisualStateGroups>
-    </Grid>
+    </ScrollViewer>
 </Page>

--- a/src/Neptunium/View/StationsPage.xaml
+++ b/src/Neptunium/View/StationsPage.xaml
@@ -35,6 +35,7 @@
 
                 <StackPanel Orientation="Horizontal">
                     <AppBarButton Icon="Play" Label="Play" Command="{Binding PlayLastPlayedStationCommand}" 
+                                  VerticalAlignment="Center"
                                   IsEnabled="{Binding NetworkAvailable, UpdateSourceTrigger=PropertyChanged}" />
                     <Grid Height="80" VerticalAlignment="Center">
                         <Grid.ColumnDefinitions>
@@ -70,7 +71,7 @@
                                        Style="{ThemeResource BodyTextBlockStyle}"
                                        TextWrapping="WrapWholeWords">
                                         <Span>
-                                            <Run Text="{Binding LastPlayedStationDescription, UpdateSourceTrigger=PropertyChanged}" />
+                                            <Run Text="{Binding LastPlayedStationDate, UpdateSourceTrigger=PropertyChanged}" />
                                         </Span>
                             </TextBlock>
                         </Grid>

--- a/src/Neptunium/View/StationsPage.xaml
+++ b/src/Neptunium/View/StationsPage.xaml
@@ -79,7 +79,7 @@
                 </StackPanel>
             </StackPanel>
 
-            <ListView ItemsSource="{Binding AvailableStations, UpdateSourceTrigger=PropertyChanged}"
+            <ListView ItemsSource="{Binding SortedAvailableStations, UpdateSourceTrigger=PropertyChanged}"
                       SelectionMode="Single"
                       Margin="5"
                       x:Name="stationsListView"
@@ -159,7 +159,7 @@
                     </DataTemplate>
                 </ListView.ItemTemplate>
             </ListView>
-            <GridView ItemsSource="{Binding AvailableStations, UpdateSourceTrigger=PropertyChanged}"
+            <GridView ItemsSource="{Binding SortedAvailableStations, UpdateSourceTrigger=PropertyChanged}"
                       SelectionMode="Single"
                       Margin="5"
                       x:Name="stationsGridView"

--- a/src/Neptunium/View/StationsPage.xaml
+++ b/src/Neptunium/View/StationsPage.xaml
@@ -34,7 +34,8 @@
                            Text="Last Played" />
 
                 <StackPanel Orientation="Horizontal">
-                    <AppBarButton Icon="Play" Label="Play" Command="{Binding PlayLastPlayedStationCommand}" />
+                    <AppBarButton Icon="Play" Label="Play" Command="{Binding PlayLastPlayedStationCommand}" 
+                                  IsEnabled="{Binding NetworkAvailable, UpdateSourceTrigger=PropertyChanged}" />
                     <Grid Height="80" VerticalAlignment="Center">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="75" />
@@ -83,6 +84,7 @@
                       x:Name="stationsListView"
                       Visibility="Visible"
                       IsItemClickEnabled="True"
+                      IsEnabled="{Binding NetworkAvailable, UpdateSourceTrigger=PropertyChanged}"
                       Grid.Row="1">
                 <ListView.HeaderTemplate>
                     <DataTemplate>
@@ -162,6 +164,7 @@
                       x:Name="stationsGridView"
                       Visibility="Collapsed"
                       IsItemClickEnabled="True"
+                      IsEnabled="{Binding NetworkAvailable, UpdateSourceTrigger=PropertyChanged}"
                       Grid.Row="1">
                 <GridView.HeaderTemplate>
                     <DataTemplate>

--- a/src/Neptunium/View/StationsPage.xaml
+++ b/src/Neptunium/View/StationsPage.xaml
@@ -229,7 +229,8 @@
             </GridView>
 
             <ProgressRing Height="60" Width="60" VerticalAlignment="Center" HorizontalAlignment="Center"
-                          IsActive="{Binding IsBusy, UpdateSourceTrigger=PropertyChanged}" />
+                          IsActive="{Binding IsBusy, UpdateSourceTrigger=PropertyChanged}"
+                          Grid.RowSpan="2"/>
 
             
         </Grid>

--- a/src/Neptunium/View/StationsPage.xaml
+++ b/src/Neptunium/View/StationsPage.xaml
@@ -81,7 +81,7 @@
 
             <ListView ItemsSource="{Binding SortedAvailableStations, UpdateSourceTrigger=PropertyChanged}"
                       SelectionMode="Single"
-                      Margin="5"
+                      Margin="5 5 5 15"
                       x:Name="stationsListView"
                       Visibility="Visible"
                       IsItemClickEnabled="True"

--- a/src/Neptunium/View/StationsPage.xaml
+++ b/src/Neptunium/View/StationsPage.xaml
@@ -71,7 +71,7 @@
                                        Style="{ThemeResource BodyTextBlockStyle}"
                                        TextWrapping="WrapWholeWords">
                                         <Span>
-                                            <Run Text="{Binding LastPlayedStationDate, UpdateSourceTrigger=PropertyChanged}" />
+                                            <Run Text="{Binding LastPlayedStationDate, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource RelTimeConv}}" />
                                         </Span>
                             </TextBlock>
                         </Grid>

--- a/src/Neptunium/View/StationsPage.xaml.cs
+++ b/src/Neptunium/View/StationsPage.xaml.cs
@@ -21,13 +21,21 @@ namespace Neptunium.View
     /// <summary>
     /// An empty page that can be used on its own or navigated to within a Frame.
     /// </summary>
-    [Crystal3.Navigation.NavigationViewModel(typeof(StationsPageViewModel), 
+    [Crystal3.Navigation.NavigationViewModel(typeof(StationsPageViewModel),
         Crystal3.Navigation.NavigationViewSupportedPlatform.Desktop | Crystal3.Navigation.NavigationViewSupportedPlatform.Mobile | Crystal3.Navigation.NavigationViewSupportedPlatform.IoT)]
     public sealed partial class StationsPage : Page
     {
         public StationsPage()
         {
             this.InitializeComponent();
+        }
+
+        private void LastPlayedPanel_LayoutUpdated(object sender, object e)
+        {
+            if (LastPlayedPanel.Visibility == Visibility.Visible)
+                LastPlayedPanelRowDef.Height = GridLength.Auto;
+            else
+                LastPlayedPanelRowDef.Height = new GridLength(0);
         }
     }
 }

--- a/src/Neptunium/View/XboxNowPlayingPage.xaml
+++ b/src/Neptunium/View/XboxNowPlayingPage.xaml
@@ -17,7 +17,7 @@
 
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
         <Grid x:Name="SongInfoPanel"
-              Visibility="{Binding CurrentSong, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource NullToVisConv}}">
+              Visibility="{Binding IsMediaEngaged, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BoolToVisConv}}">
             <Grid.RowDefinitions>
                 <RowDefinition Height="*" />
                 <RowDefinition Height="200" />
@@ -79,7 +79,7 @@
 
         <Grid x:Name="NoSongInfoPanel" 
               Padding="48 0 48 0"
-              Visibility="{Binding CurrentSong, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource InvNullToVisConv}}">
+              Visibility="{Binding IsMediaEngaged, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource InvBoolToVisConv}}">
             <TextBlock Text="Nothing is playing. Go pick a station to stream!"
                        Style="{ThemeResource CaptionTextBlockStyle}" 
                        VerticalAlignment="Center" HorizontalAlignment="Center" />

--- a/src/Neptunium/View/XboxStationsPage.xaml
+++ b/src/Neptunium/View/XboxStationsPage.xaml
@@ -102,7 +102,7 @@
                                             Foreground="{ThemeResource SystemControlForegroundBaseMediumHighBrush}"
                                             Style="{ThemeResource BodyTextBlockStyle}">
                                         <Span>
-                                            <Run Text="{Binding LastPlayedStationDate, UpdateSourceTrigger=PropertyChanged}" />
+                                            <Run Text="{Binding LastPlayedStationDate, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource RelTimeConv}}" />
                                         </Span>
                         </TextBlock>
                     </Grid>

--- a/src/Neptunium/View/XboxStationsPage.xaml
+++ b/src/Neptunium/View/XboxStationsPage.xaml
@@ -67,7 +67,8 @@
                            Text="Last Played" />
 
             <StackPanel Orientation="Horizontal">
-                <AppBarButton Icon="Play" Label="Play" Command="{Binding PlayLastPlayedStationCommand}" />
+                <AppBarButton Icon="Play" Label="Play" Command="{Binding PlayLastPlayedStationCommand}"
+                              IsEnabled="{Binding NetworkAvailable, UpdateSourceTrigger=PropertyChanged}" />
                 <Grid Height="80" VerticalAlignment="Center">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="75" />
@@ -116,6 +117,7 @@
                   IsItemClickEnabled="True"
                   Style="{StaticResource TitleSafeGridViewStyle}"
                   ItemClick="stationsGridView_ItemClick"
+                  IsEnabled="{Binding NetworkAvailable, UpdateSourceTrigger=PropertyChanged}"
                   Grid.Row="1">
             <GridView.Resources>
                 <Style TargetType="GridViewItemPresenter">

--- a/src/Neptunium/View/XboxStationsPage.xaml
+++ b/src/Neptunium/View/XboxStationsPage.xaml
@@ -50,13 +50,73 @@
     </Page.Resources>
     
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" Padding="48,0,48,0">
+        <Grid.RowDefinitions>
+            <RowDefinition x:Name="LastPlayedPanelRowDef" Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <StackPanel Grid.Row="0"
+                        Margin="0 0 0 0"
+                        Orientation="Vertical"
+                        x:Name="LastPlayedPanel"
+                        LayoutUpdated="LastPlayedPanel_LayoutUpdated"
+                        Visibility="{Binding LastPlayedStation, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource NullToVisConv}}">
+
+            <TextBlock Style="{ThemeResource TitleTextBlockStyle}"
+                           Margin="10 0"
+                           Text="Last Played" />
+
+            <StackPanel Orientation="Horizontal">
+                <AppBarButton Icon="Play" Label="Play" Command="{Binding PlayLastPlayedStationCommand}" />
+                <Grid Height="80" VerticalAlignment="Center">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="75" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+
+                    <uwp:ImageEx Grid.Column="0"
+                                         Stretch="Fill"
+                                         Width="75"
+                                         Height="75"
+                                         Margin="0 5 0 0"
+                                         VerticalAlignment="Top"
+                                         IsCacheEnabled="True">
+                        <uwp:ImageEx.Source>
+                            <BitmapImage UriSource="{Binding LastPlayedStationLogoUrl, UpdateSourceTrigger=PropertyChanged}" />
+                        </uwp:ImageEx.Source>
+                    </uwp:ImageEx>
+
+                    <Grid Grid.Column="1" Margin="15 0" VerticalAlignment="Center">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
+
+                        <TextBlock Text="{Binding LastPlayedStation, UpdateSourceTrigger=PropertyChanged}" Grid.Row="0" 
+                                            Style="{ThemeResource BaseTextBlockStyle}"
+                                            Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}"
+                                            VerticalAlignment="Bottom"/>
+                        <TextBlock Grid.Row="1"
+                                            VerticalAlignment="Top"
+                                            Foreground="{ThemeResource SystemControlForegroundBaseMediumHighBrush}"
+                                            Style="{ThemeResource BodyTextBlockStyle}">
+                                        <Span>
+                                            <Run Text="{Binding LastPlayedStationDescription, UpdateSourceTrigger=PropertyChanged}" />
+                                        </Span>
+                        </TextBlock>
+                    </Grid>
+                </Grid>
+            </StackPanel>
+        </StackPanel>
+
         <GridView ItemsSource="{Binding AvailableStations, UpdateSourceTrigger=PropertyChanged}"
                   SelectionMode="Single"
                   Margin="5"
                   x:Name="stationsGridView"
                   IsItemClickEnabled="True"
                   Style="{StaticResource TitleSafeGridViewStyle}"
-                  ItemClick="stationsGridView_ItemClick">
+                  ItemClick="stationsGridView_ItemClick"
+                  Grid.Row="1">
             <GridView.Resources>
                 <Style TargetType="GridViewItemPresenter">
                     <Setter Property="SelectedBackground" Value="{x:Null}" />
@@ -100,6 +160,7 @@
         </GridView>
 
         <ProgressRing Height="60" Width="60" VerticalAlignment="Center" HorizontalAlignment="Center"
+                      Grid.RowSpan="2"
                       IsActive="{Binding IsBusy, UpdateSourceTrigger=PropertyChanged}" />
     </Grid>
 </Page>

--- a/src/Neptunium/View/XboxStationsPage.xaml
+++ b/src/Neptunium/View/XboxStationsPage.xaml
@@ -102,7 +102,7 @@
                                             Foreground="{ThemeResource SystemControlForegroundBaseMediumHighBrush}"
                                             Style="{ThemeResource BodyTextBlockStyle}">
                                         <Span>
-                                            <Run Text="{Binding LastPlayedStationDescription, UpdateSourceTrigger=PropertyChanged}" />
+                                            <Run Text="{Binding LastPlayedStationDate, UpdateSourceTrigger=PropertyChanged}" />
                                         </Span>
                         </TextBlock>
                     </Grid>

--- a/src/Neptunium/View/XboxStationsPage.xaml
+++ b/src/Neptunium/View/XboxStationsPage.xaml
@@ -118,7 +118,6 @@
                   IsItemClickEnabled="True"
                   Style="{StaticResource TitleSafeGridViewStyle}"
                   ItemClick="stationsGridView_ItemClick"
-                  Header="Stations"
                   IsEnabled="{Binding NetworkAvailable, UpdateSourceTrigger=PropertyChanged}"
                   Grid.Row="1">
             <GridView.Resources>
@@ -126,6 +125,13 @@
                     <Setter Property="SelectedBackground" Value="{x:Null}" />
                 </Style>
             </GridView.Resources>
+            <GridView.HeaderTemplate>
+                <DataTemplate>
+                    <TextBlock Style="{ThemeResource TitleTextBlockStyle}"
+                           Margin="10 0"
+                           Text="Stations" />
+                </DataTemplate>
+            </GridView.HeaderTemplate>
             <GridView.ItemTemplate>
                 <DataTemplate>
                     <Grid Width="125" Height="200">

--- a/src/Neptunium/View/XboxStationsPage.xaml
+++ b/src/Neptunium/View/XboxStationsPage.xaml
@@ -110,7 +110,7 @@
             </StackPanel>
         </StackPanel>
 
-        <GridView ItemsSource="{Binding AvailableStations, UpdateSourceTrigger=PropertyChanged}"
+        <GridView ItemsSource="{Binding SortedAvailableStations, UpdateSourceTrigger=PropertyChanged}"
                   SelectionMode="Single"
                   Margin="5"
                   x:Name="stationsGridView"

--- a/src/Neptunium/View/XboxStationsPage.xaml
+++ b/src/Neptunium/View/XboxStationsPage.xaml
@@ -68,6 +68,7 @@
 
             <StackPanel Orientation="Horizontal">
                 <AppBarButton Icon="Play" Label="Play" Command="{Binding PlayLastPlayedStationCommand}"
+                              x:Name="LastPlayedPlayButton"
                               IsEnabled="{Binding NetworkAvailable, UpdateSourceTrigger=PropertyChanged}" />
                 <Grid Height="80" VerticalAlignment="Center">
                     <Grid.ColumnDefinitions>
@@ -117,6 +118,7 @@
                   IsItemClickEnabled="True"
                   Style="{StaticResource TitleSafeGridViewStyle}"
                   ItemClick="stationsGridView_ItemClick"
+                  Header="Stations"
                   IsEnabled="{Binding NetworkAvailable, UpdateSourceTrigger=PropertyChanged}"
                   Grid.Row="1">
             <GridView.Resources>

--- a/src/Neptunium/View/XboxStationsPage.xaml.cs
+++ b/src/Neptunium/View/XboxStationsPage.xaml.cs
@@ -106,7 +106,8 @@ namespace Neptunium.View
 
         public void SetTopFocus(UIElement elementAbove)
         {
-            stationsGridView.XYFocusUp = elementAbove;
+            LastPlayedPlayButton.XYFocusUp = elementAbove;
+            stationsGridView.XYFocusUp = LastPlayedPlayButton;
         }
 
         public void SetBottomFocus(UIElement elementBelow)

--- a/src/Neptunium/View/XboxStationsPage.xaml.cs
+++ b/src/Neptunium/View/XboxStationsPage.xaml.cs
@@ -113,5 +113,13 @@ namespace Neptunium.View
         {
 
         }
+
+        private void LastPlayedPanel_LayoutUpdated(object sender, object e)
+        {
+            if (LastPlayedPanel.Visibility == Visibility.Visible)
+                LastPlayedPanelRowDef.Height = GridLength.Auto;
+            else
+                LastPlayedPanelRowDef.Height = new GridLength(0);
+        }
     }
 }

--- a/src/Neptunium/ViewModel/AppShellViewModel.cs
+++ b/src/Neptunium/ViewModel/AppShellViewModel.cs
@@ -15,6 +15,7 @@ using Windows.System.UserProfile;
 using Windows.Services.Store;
 using Windows.Foundation;
 using Windows.UI.Xaml;
+using Neptunium.Core.Media.Audio;
 
 namespace Neptunium.ViewModel
 {
@@ -77,12 +78,29 @@ namespace Neptunium.ViewModel
             NepApp.SongManager.PreSongChanged += SongManager_PreSongChanged;
             NepApp.SongManager.SongChanged += SongManager_SongChanged;
             NepApp.SongManager.StationRadioProgramStarted += SongManager_StationRadioProgramStarted;
+            NepApp.MediaPlayer.Audio.HeadsetDetector.IsHeadsetPluggedInChanged += HeadsetDetector_IsHeadsetPluggedInChanged;
+
+            if (NepApp.MediaPlayer.Audio.HeadsetDetector.IsHeadsetPluggedIn)
+            {
+                ShowOverlayForHeadphonesStatus(true);
+            }
 
             if (UserProfilePersonalizationSettings.IsSupported())
             {
                 NepApp.SongManager.SongArtworkAvailable += SongManager_SongArtworkAvailable;
                 NepApp.SongManager.NoSongArtworkAvailable += SongManager_NoSongArtworkAvailable;
             }
+        }
+
+        private void HeadsetDetector_IsHeadsetPluggedInChanged(object sender, EventArgs e)
+        {
+            bool isPluggedIn = ((IHeadsetDetector)sender).IsHeadsetPluggedIn;
+            ShowOverlayForHeadphonesStatus(isPluggedIn);
+        }
+
+        private static void ShowOverlayForHeadphonesStatus(bool isPluggedIn)
+        {
+            NepApp.UI.Overlay.ShowSnackBarMessageAsync(isPluggedIn ? "Headphones connected." : "Headphones disconnected.");
         }
 
         private async void SongManager_NoSongArtworkAvailable(object sender, Media.Songs.NepAppSongMetadataArtworkEventArgs e)

--- a/src/Neptunium/ViewModel/AppShellViewModel.cs
+++ b/src/Neptunium/ViewModel/AppShellViewModel.cs
@@ -61,7 +61,16 @@ namespace Neptunium.ViewModel
                 NepApp.UI.AddNavigationRoute("History", typeof(SongHistoryPageViewModel), "");
                 NepApp.UI.AddNavigationRoute("Schedule", typeof(StationProgramsPageViewModel), "");
                 NepApp.UI.AddNavigationRoute("Settings", typeof(SettingsPageViewModel), "");
-                NepApp.UI.AddNavigationRoute("Remote", typeof(ServerRemotePageViewModel), "");
+
+#if RELEASE
+                if ((bool)NepApp.Settings.GetSetting(AppSettings.ShowRemoteMenu))
+                {
+#endif
+                    NepApp.UI.AddNavigationRoute("Remote", typeof(ServerRemotePageViewModel), "");
+#if RELEASE
+                }
+#endif
+
                 NepApp.UI.AddNavigationRoute("About", typeof(AboutPageViewModel), "");
             }
 

--- a/src/Neptunium/ViewModel/AppShellViewModel.cs
+++ b/src/Neptunium/ViewModel/AppShellViewModel.cs
@@ -62,13 +62,15 @@ namespace Neptunium.ViewModel
             NepApp.UI.AddNavigationRoute("Settings", typeof(SettingsPageViewModel), "");
 
 #if !DEBUG
-                if ((bool)NepApp.Settings.GetSetting(AppSettings.ShowRemoteMenu))
-                {
+            if ((bool)NepApp.Settings.GetSetting(AppSettings.ShowRemoteMenu))
+            {
 #endif
-            NepApp.UI.AddNavigationRoute("Remote", typeof(ServerRemotePageViewModel), "");
+                NepApp.UI.AddNavigationRoute("Remote", typeof(ServerRemotePageViewModel), "");
 #if !DEBUG
-                }
+            }
 #endif
+
+            NepApp.UI.AddNavigationRoute("About", typeof(AboutPageViewModel), "");
 
 
             NepApp.MediaPlayer.IsPlayingChanged += Media_IsPlayingChanged;

--- a/src/Neptunium/ViewModel/AppShellViewModel.cs
+++ b/src/Neptunium/ViewModel/AppShellViewModel.cs
@@ -195,21 +195,9 @@ namespace Neptunium.ViewModel
             NepApp.UI.Notifier.UpdateLiveTile((ExtendedSongMetadata)e.Metadata);
         }
 
-        private async void SongManager_PreSongChanged(object sender, Media.Songs.NepAppSongChangedEventArgs e)
+        private void SongManager_PreSongChanged(object sender, Media.Songs.NepAppSongChangedEventArgs e)
         {
-            if (e.Metadata == null) return;
 
-            try
-            {
-                if ((bool)NepApp.Settings.GetSetting(AppSettings.SaySongNotificationsWhenHeadphonesAreConnected) && !e.Metadata.IsUnknownMetadata)
-                {
-                    await VoiceUtility.AnnonceSongMetadataUsingVoiceAsync(e, VoiceMode.Headphones);
-                }
-            }
-            catch (Exception ex)
-            {
-
-            }
         }
 
         private void Media_IsPlayingChanged(object sender, Media.NepAppMediaPlayerManager.NepAppMediaPlayerManagerIsPlayingEventArgs e)

--- a/src/Neptunium/ViewModel/AppShellViewModel.cs
+++ b/src/Neptunium/ViewModel/AppShellViewModel.cs
@@ -16,6 +16,7 @@ using Windows.Services.Store;
 using Windows.Foundation;
 using Windows.UI.Xaml;
 using Neptunium.Core.Media.Audio;
+using Neptunium.Core.Media;
 
 namespace Neptunium.ViewModel
 {
@@ -196,9 +197,18 @@ namespace Neptunium.ViewModel
 
         private async void SongManager_PreSongChanged(object sender, Media.Songs.NepAppSongChangedEventArgs e)
         {
-            if ((bool)NepApp.Settings.GetSetting(AppSettings.SaySongNotificationsWhenHeadphonesAreConnected) && !e.Metadata.IsUnknownMetadata)
+            if (e.Metadata == null) return;
+
+            try
             {
-                await NepApp.MediaPlayer.Bluetooth.AnnonceSongMetadataUsingVoiceAsync(e);
+                if ((bool)NepApp.Settings.GetSetting(AppSettings.SaySongNotificationsWhenHeadphonesAreConnected) && !e.Metadata.IsUnknownMetadata)
+                {
+                    await VoiceUtility.AnnonceSongMetadataUsingVoiceAsync(e, VoiceMode.Headphones);
+                }
+            }
+            catch (Exception ex)
+            {
+
             }
         }
 

--- a/src/Neptunium/ViewModel/AppShellViewModel.cs
+++ b/src/Neptunium/ViewModel/AppShellViewModel.cs
@@ -98,9 +98,12 @@ namespace Neptunium.ViewModel
             ShowOverlayForHeadphonesStatus(isPluggedIn);
         }
 
-        private static void ShowOverlayForHeadphonesStatus(bool isPluggedIn)
+        private void ShowOverlayForHeadphonesStatus(bool isPluggedIn)
         {
-            NepApp.UI.Overlay.ShowSnackBarMessageAsync(isPluggedIn ? "Headphones connected." : "Headphones disconnected.");
+            App.Dispatcher.RunWhenIdleAsync(() =>
+            {
+                NepApp.UI.Overlay.ShowSnackBarMessageAsync(isPluggedIn ? "Headphones connected." : "Headphones disconnected.");
+            });
         }
 
         private async void SongManager_NoSongArtworkAvailable(object sender, Media.Songs.NepAppSongMetadataArtworkEventArgs e)
@@ -191,9 +194,12 @@ namespace Neptunium.ViewModel
             NepApp.UI.Notifier.UpdateLiveTile((ExtendedSongMetadata)e.Metadata);
         }
 
-        private void SongManager_PreSongChanged(object sender, Media.Songs.NepAppSongChangedEventArgs e)
+        private async void SongManager_PreSongChanged(object sender, Media.Songs.NepAppSongChangedEventArgs e)
         {
-
+            if ((bool)NepApp.Settings.GetSetting(AppSettings.SaySongNotificationsWhenHeadphonesAreConnected) && !e.Metadata.IsUnknownMetadata)
+            {
+                await NepApp.MediaPlayer.Bluetooth.AnnonceSongMetadataUsingVoiceAsync(e);
+            }
         }
 
         private void Media_IsPlayingChanged(object sender, Media.NepAppMediaPlayerManager.NepAppMediaPlayerManagerIsPlayingEventArgs e)

--- a/src/Neptunium/ViewModel/AppShellViewModel.cs
+++ b/src/Neptunium/ViewModel/AppShellViewModel.cs
@@ -90,7 +90,7 @@ namespace Neptunium.ViewModel
             if (!string.IsNullOrWhiteSpace(e.Data))
             {
                 string data = e.Data.Trim();
-                string[] dataBits = data.Split(',');
+                string[] dataBits = data.Split(NepAppServerFrontEndManager.NepAppServerClient.MessageTypeSeperator);
 
                 if (dataBits.Length > 0)
                 {
@@ -104,7 +104,11 @@ namespace Neptunium.ViewModel
                                 if (station != null)
                                 {
                                     var stream = station.Streams.First();
-                                    await NepApp.MediaPlayer.TryStreamStationAsync(stream);
+                                    await await App.Dispatcher.RunAsync(async () =>
+                                    {
+                                        await NepApp.MediaPlayer.TryStreamStationAsync(stream);
+                                    });
+                                    
                                 }
                             }
 

--- a/src/Neptunium/ViewModel/AppShellViewModel.cs
+++ b/src/Neptunium/ViewModel/AppShellViewModel.cs
@@ -62,12 +62,12 @@ namespace Neptunium.ViewModel
                 NepApp.UI.AddNavigationRoute("Schedule", typeof(StationProgramsPageViewModel), "");
                 NepApp.UI.AddNavigationRoute("Settings", typeof(SettingsPageViewModel), "");
 
-#if RELEASE
+#if !DEBUG
                 if ((bool)NepApp.Settings.GetSetting(AppSettings.ShowRemoteMenu))
                 {
 #endif
                     NepApp.UI.AddNavigationRoute("Remote", typeof(ServerRemotePageViewModel), "");
-#if RELEASE
+#if !DEBUG
                 }
 #endif
 

--- a/src/Neptunium/ViewModel/Dialog/StationInfoDialogFragment.cs
+++ b/src/Neptunium/ViewModel/Dialog/StationInfoDialogFragment.cs
@@ -33,6 +33,13 @@ namespace Neptunium.ViewModel.Dialog
             ResultTaskCompletionSource.SetResult(new NepAppUIManagerDialogResult() { ResultType = NepAppUIManagerDialogResult.NepAppUIManagerDialogResultType.Positive });
             dialogAnswered = true;
         });
+        public RelayCommand PlayStreamCommand => new RelayCommand(x =>
+        {
+            if (dialogAnswered) return;
+            ResultTaskCompletionSource.SetResult(new NepAppUIManagerDialogResult() { ResultType = NepAppUIManagerDialogResult.NepAppUIManagerDialogResultType.Positive, Selection = x });
+            dialogAnswered = true;
+        });
+
 
         public RelayCommand OpenStationWebsiteCommand => new RelayCommand(async x =>
         {

--- a/src/Neptunium/ViewModel/Dialog/StationInfoDialogFragment.cs
+++ b/src/Neptunium/ViewModel/Dialog/StationInfoDialogFragment.cs
@@ -26,12 +26,14 @@ namespace Neptunium.ViewModel.Dialog
             if (dialogAnswered) return;
             ResultTaskCompletionSource.SetResult(NepAppUIManagerDialogResult.Declined);
             dialogAnswered = true;
+            NepApp.UI.Notifier.VibrateClick();
         });
         public RelayCommand PlayCommand => new RelayCommand(x =>
         {
             if (dialogAnswered) return;
             ResultTaskCompletionSource.SetResult(new NepAppUIManagerDialogResult() { ResultType = NepAppUIManagerDialogResult.NepAppUIManagerDialogResultType.Positive });
             dialogAnswered = true;
+            NepApp.UI.Notifier.VibrateClick();
         });
         public RelayCommand PlayStreamCommand => new RelayCommand(x =>
         {
@@ -45,12 +47,14 @@ namespace Neptunium.ViewModel.Dialog
         {
             if (!string.IsNullOrWhiteSpace(Station.Site))
             {
+                NepApp.UI.Notifier.VibrateClick();
                 await Launcher.LaunchUriAsync(new Uri(Station.Site));
             }
         });
 
         public RelayCommand PinStationCommand => new RelayCommand(async x =>
         {
+            NepApp.UI.Notifier.VibrateClick();
             if (!NepApp.UI.Notifier.CheckIfStationTilePinned(Station))
             {
                 try

--- a/src/Neptunium/ViewModel/NowPlayingPageViewModel.cs
+++ b/src/Neptunium/ViewModel/NowPlayingPageViewModel.cs
@@ -60,16 +60,51 @@ namespace Neptunium.ViewModel
             private set { SetPropertyValue<Uri>(value: value); }
         }
 
+        public bool IsPlaying
+        {
+            get { return GetPropertyValue<bool>(); }
+            private set { SetPropertyValue<bool>(value: value); }
+        }
+
+        public bool IsMediaEngaged
+        {
+            get { return GetPropertyValue<bool>(); }
+            private set { SetPropertyValue<bool>(value: value); }
+        }
+
         protected override void OnNavigatedTo(object sender, CrystalNavigationEventArgs e)
         {
+            NepApp.MediaPlayer.IsPlayingChanged += MediaPlayer_IsPlayingChanged;
+            NepApp.MediaPlayer.MediaEngagementChanged += MediaPlayer_MediaEngagementChanged;
             NepApp.SongManager.PreSongChanged += SongManager_PreSongChanged;
             NepApp.SongManager.SongChanged += SongManager_SongChanged;
             NepApp.SongManager.SongArtworkProcessingComplete += SongManager_SongArtworkProcessingComplete;
+
+            IsPlaying = NepApp.MediaPlayer.IsPlaying;
+            IsMediaEngaged = NepApp.MediaPlayer.IsMediaEngaged;
 
             UpdateMetadata();
             UpdateArtwork();
 
             base.OnNavigatedTo(sender, e);
+        }
+
+        private void MediaPlayer_MediaEngagementChanged(object sender, EventArgs e)
+        {
+            App.Dispatcher.RunWhenIdleAsync(() =>
+            {
+                IsPlaying = NepApp.MediaPlayer.IsPlaying;
+                IsMediaEngaged = NepApp.MediaPlayer.IsMediaEngaged;
+            });
+        }
+
+        private void MediaPlayer_IsPlayingChanged(object sender, Media.NepAppMediaPlayerManager.NepAppMediaPlayerManagerIsPlayingEventArgs e)
+        {
+            App.Dispatcher.RunWhenIdleAsync(() =>
+            {
+                IsPlaying = NepApp.MediaPlayer.IsPlaying;
+                UpdateMetadata();
+            });
         }
 
         private void SongManager_SongArtworkProcessingComplete(object sender, EventArgs e)
@@ -139,6 +174,8 @@ namespace Neptunium.ViewModel
 
         protected override void OnNavigatedFrom(object sender, CrystalNavigationEventArgs e)
         {
+            NepApp.MediaPlayer.MediaEngagementChanged -= MediaPlayer_MediaEngagementChanged;
+            NepApp.MediaPlayer.IsPlayingChanged -= MediaPlayer_IsPlayingChanged;
             NepApp.SongManager.PreSongChanged -= SongManager_PreSongChanged;
             NepApp.SongManager.SongChanged -= SongManager_SongChanged;
             NepApp.SongManager.SongArtworkProcessingComplete -= SongManager_SongArtworkProcessingComplete;
@@ -148,7 +185,7 @@ namespace Neptunium.ViewModel
 
         private void UpdateMetadata()
         {
-            CurrentSong = NepApp.SongManager.CurrentSong;
+            CurrentSong = NepApp.SongManager.GetCurrentSongOrUnknown();
             CurrentStation = NepApp.MediaPlayer.CurrentStream?.ParentStation;
 
             UpdateArtwork();

--- a/src/Neptunium/ViewModel/NowPlayingPageViewModel.cs
+++ b/src/Neptunium/ViewModel/NowPlayingPageViewModel.cs
@@ -127,7 +127,6 @@ namespace Neptunium.ViewModel
 
         private void SongManager_SongChanged(object sender, Media.Songs.NepAppSongChangedEventArgs e)
         {
-
         }
 
         private void SongManager_PreSongChanged(object sender, Media.Songs.NepAppSongChangedEventArgs e)

--- a/src/Neptunium/ViewModel/Server/ServerShellViewModel.cs
+++ b/src/Neptunium/ViewModel/Server/ServerShellViewModel.cs
@@ -1,0 +1,27 @@
+﻿using Crystal3.Model;
+using Crystal3.Navigation;
+using Neptunium.Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Neptunium.ViewModel.Server
+{
+    public class ServerShellViewModel: ViewModelBase
+    {
+        protected override void OnNavigatedTo(object sender, CrystalNavigationEventArgs e)
+        {
+            //if its IoT
+            NepApp.ServerFrontEnd.DataReceived += ServerFrontEnd_DataReceived;
+
+            base.OnNavigatedTo(sender, e);
+        }
+
+        private void ServerFrontEnd_DataReceived(object sender, NepAppServerFrontEndManager.NepAppServerFrontEndManagerDataReceivedEventArgs e)
+        {
+           
+        }
+    }
+}

--- a/src/Neptunium/ViewModel/ServerRemotePageViewModel.cs
+++ b/src/Neptunium/ViewModel/ServerRemotePageViewModel.cs
@@ -1,8 +1,11 @@
 ﻿using Crystal3.Model;
 using Crystal3.Navigation;
 using Crystal3.UI.Commands;
+using Microsoft.Toolkit.Uwp.UI;
+using Neptunium.Core.Stations;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Net;
 using System.Text;
@@ -16,35 +19,61 @@ namespace Neptunium.ViewModel
         protected override void OnNavigatedTo(object sender, CrystalNavigationEventArgs e)
         {
             Neptunium.Core.NepAppServerFrontEndManager.NepAppServerClient serverClient = new Core.NepAppServerFrontEndManager.NepAppServerClient();
+            Neptunium.Core.NepAppServerFrontEndManager.NepAppServerDiscoverer serverFinder = new Core.NepAppServerFrontEndManager.NepAppServerDiscoverer();
 
-            ConnectCommand = new ManualRelayCommand(async parameter =>
+            ConnectCommand = new RelayCommand(async parameter =>
             {
-                try
+                if (!IsConnected)
                 {
-                    await serverClient.TryConnectAsync(IPAddress.Parse((string)parameter);
-                    IsConnected = true;
+                    try
+                    {
+                        await serverClient.TryConnectAsync(IPAddress.Parse((string)parameter));
+                        IsConnected = true;
 
-                    serverClient.
-                }
-                catch (Exception ex)
-                {
-                    IsConnected = false;
+                        //todo subscribe to an event from serverClient for receiving metadata.
+
+                        LoadStations();
+                    }
+                    catch (Exception ex)
+                    {
+                        IsConnected = false;
+                    }
                 }
             });
 
-            DisconnectCommand = new ManualRelayCommand(parameter =>
+            DisconnectCommand = new RelayCommand(parameter =>
             {
+                if (IsConnected)
+                {
+                    serverClient?.Dispose();
 
+                    AvailableStations.Clear();
+                    SortedAvailableStations.Clear();
+                }
             });
 
-            ConnectCommand.SetCanExecute(!IsConnected);
-            DisconnectCommand.SetCanExecute(IsConnected);
+            RaisePropertyChanged(nameof(ConnectCommand));
+            RaisePropertyChanged(nameof(DisconnectCommand));
 
             base.OnNavigatedTo(sender, e);
         }
 
+        private void LoadStations()
+        {
+            AvailableStations = new ObservableCollection<StationItem>();
+            SortedAvailableStations = new AdvancedCollectionView(AvailableStations, false);
+            SortedAvailableStations.SortDescriptions.Add(new SortDescription("Name", SortDirection.Ascending, null));
+
+            NepApp.Stations.ObserveStationsAsync().Subscribe<StationItem>((StationItem item) =>
+            {
+                AvailableStations.Add(item);
+            });
+        }
+
         protected override void OnNavigatedFrom(object sender, CrystalNavigationEventArgs e)
         {
+            serverClient?.Dispose();
+
             base.OnNavigatedFrom(sender, e);
         }
 
@@ -54,14 +83,23 @@ namespace Neptunium.ViewModel
             private set
             {
                 SetPropertyValue<bool>(value: value);
-
-                ConnectCommand.SetCanExecute(!value);
-                DisconnectCommand.SetCanExecute(value);
             }
         }
 
-        public ManualRelayCommand ConnectCommand { get; private set; }
+        public ObservableCollection<StationItem> AvailableStations
+        {
+            get { return GetPropertyValue<ObservableCollection<StationItem>>(); }
+            private set { SetPropertyValue<ObservableCollection<StationItem>>(value: value); }
+        }
 
-        public ManualRelayCommand DisconnectCommand { get; private set; }
+        public IAdvancedCollectionView SortedAvailableStations
+        {
+            get { return GetPropertyValue<IAdvancedCollectionView>(); }
+            private set { SetPropertyValue<IAdvancedCollectionView>(value: value); }
+        }
+
+        public RelayCommand ConnectCommand { get; private set; }
+
+        public RelayCommand DisconnectCommand { get; private set; }
     }
 }

--- a/src/Neptunium/ViewModel/ServerRemotePageViewModel.cs
+++ b/src/Neptunium/ViewModel/ServerRemotePageViewModel.cs
@@ -52,8 +52,26 @@ namespace Neptunium.ViewModel
                 }
             });
 
+            SendStationCommand = new RelayCommand(parameter =>
+            {
+                if (IsConnected && parameter != null)
+                {
+                    serverClient?.AskServerToStreamStation((StationItem)parameter);
+                }
+            });
+
+            SendStopCommand = new RelayCommand(parameter =>
+            {
+                if (IsConnected)
+                {
+                    serverClient?.AskServerToStop();
+                }
+            });
+
             RaisePropertyChanged(nameof(ConnectCommand));
             RaisePropertyChanged(nameof(DisconnectCommand));
+            RaisePropertyChanged(nameof(SendStationCommand));
+            RaisePropertyChanged(nameof(SendStopCommand));
 
             base.OnNavigatedTo(sender, e);
         }
@@ -101,5 +119,9 @@ namespace Neptunium.ViewModel
         public RelayCommand ConnectCommand { get; private set; }
 
         public RelayCommand DisconnectCommand { get; private set; }
+
+        public RelayCommand SendStationCommand { get; private set; }
+
+        public RelayCommand SendStopCommand { get; private set; }
     }
 }

--- a/src/Neptunium/ViewModel/ServerRemotePageViewModel.cs
+++ b/src/Neptunium/ViewModel/ServerRemotePageViewModel.cs
@@ -23,6 +23,8 @@ namespace Neptunium.ViewModel
                 {
                     await serverClient.TryConnectAsync(IPAddress.Parse((string)parameter);
                     IsConnected = true;
+
+                    serverClient.
                 }
                 catch (Exception ex)
                 {

--- a/src/Neptunium/ViewModel/ServerRemotePageViewModel.cs
+++ b/src/Neptunium/ViewModel/ServerRemotePageViewModel.cs
@@ -1,17 +1,43 @@
 ﻿using Crystal3.Model;
 using Crystal3.Navigation;
+using Crystal3.UI.Commands;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace Neptunium.ViewModel
 {
-    public class ServerRemotePageViewModel: ViewModelBase
+    public class ServerRemotePageViewModel : ViewModelBase
     {
+        private Neptunium.Core.NepAppServerFrontEndManager.NepAppServerClient serverClient = null;
         protected override void OnNavigatedTo(object sender, CrystalNavigationEventArgs e)
         {
+            Neptunium.Core.NepAppServerFrontEndManager.NepAppServerClient serverClient = new Core.NepAppServerFrontEndManager.NepAppServerClient();
+
+            ConnectCommand = new ManualRelayCommand(async parameter =>
+            {
+                try
+                {
+                    await serverClient.TryConnectAsync(IPAddress.Parse((string)parameter);
+                    IsConnected = true;
+                }
+                catch (Exception ex)
+                {
+                    IsConnected = false;
+                }
+            });
+
+            DisconnectCommand = new ManualRelayCommand(parameter =>
+            {
+
+            });
+
+            ConnectCommand.SetCanExecute(!IsConnected);
+            DisconnectCommand.SetCanExecute(IsConnected);
+
             base.OnNavigatedTo(sender, e);
         }
 
@@ -19,5 +45,21 @@ namespace Neptunium.ViewModel
         {
             base.OnNavigatedFrom(sender, e);
         }
+
+        public bool IsConnected
+        {
+            get { return GetPropertyValue<bool>(); }
+            private set
+            {
+                SetPropertyValue<bool>(value: value);
+
+                ConnectCommand.SetCanExecute(!value);
+                DisconnectCommand.SetCanExecute(value);
+            }
+        }
+
+        public ManualRelayCommand ConnectCommand { get; private set; }
+
+        public ManualRelayCommand DisconnectCommand { get; private set; }
     }
 }

--- a/src/Neptunium/ViewModel/ServerRemotePageViewModel.cs
+++ b/src/Neptunium/ViewModel/ServerRemotePageViewModel.cs
@@ -1,0 +1,23 @@
+﻿using Crystal3.Model;
+using Crystal3.Navigation;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Neptunium.ViewModel
+{
+    public class ServerRemotePageViewModel: ViewModelBase
+    {
+        protected override void OnNavigatedTo(object sender, CrystalNavigationEventArgs e)
+        {
+            base.OnNavigatedTo(sender, e);
+        }
+
+        protected override void OnNavigatedFrom(object sender, CrystalNavigationEventArgs e)
+        {
+            base.OnNavigatedFrom(sender, e);
+        }
+    }
+}

--- a/src/Neptunium/ViewModel/ServerRemotePageViewModel.cs
+++ b/src/Neptunium/ViewModel/ServerRemotePageViewModel.cs
@@ -47,15 +47,13 @@ namespace Neptunium.ViewModel
 
             DisconnectCommand = new RelayCommand(parameter =>
             {
-                if (IsConnected)
+                if (IsConnected && serverClient != null)
                 {
+                    IsConnected = false;
                     serverClient.SongChanged -= ServerClient_SongChanged;
                     serverClient.PropertyChanged -= ServerClient_PropertyChanged;
                     serverClient?.Dispose();
                     serverClient = null;
-
-                    AvailableStations.Clear();
-                    SortedAvailableStations.Clear();
                 }
             });
 
@@ -124,6 +122,9 @@ namespace Neptunium.ViewModel
             }
 
             serverFinder?.Dispose();
+
+            AvailableStations.Clear();
+            SortedAvailableStations.Clear();
 
             base.OnNavigatedFrom(sender, e);
         }

--- a/src/Neptunium/ViewModel/SettingsPageViewModel.cs
+++ b/src/Neptunium/ViewModel/SettingsPageViewModel.cs
@@ -46,7 +46,7 @@ namespace Neptunium.ViewModel
 
         private void Settings_SettingChanged(object sender, Core.Settings.NepAppSettingChangedEventArgs e)
         {
-            switch(e.ChangedSetting)
+            switch (e.ChangedSetting)
             {
                 case AppSettings.FallBackLockScreenImageUri:
                     RaisePropertyChanged(nameof(FallBackLockScreenArtworkUri));
@@ -100,6 +100,28 @@ namespace Neptunium.ViewModel
         {
             get { return GetPropertyValue<string>(); }
             set { SetPropertyValue<string>(value: value); }
+        }
+
+        public bool ConserveData
+        {
+            get { return (bool)NepApp.Settings.GetSetting(AppSettings.AutomaticallyConserveDataWhenOnMeteredConnections); }
+            set
+            {
+                NepApp.Settings.SetSetting(AppSettings.AutomaticallyConserveDataWhenOnMeteredConnections, value);
+
+                if (!value)
+                {
+                    //automatically set Choose Bitrate to false if "Conserve Data" is turned off.
+                    ChooseBitrate = false;
+                    RaisePropertyChanged(nameof(ChooseBitrate));
+                }
+            }
+        }
+
+        public bool ChooseBitrate
+        {
+            get { return (bool)NepApp.Settings.GetSetting(AppSettings.AutomaticallyDetermineAppropriateBitrateBasedOnConnection); }
+            set { NepApp.Settings.SetSetting(AppSettings.AutomaticallyDetermineAppropriateBitrateBasedOnConnection, value); }
         }
     }
 }

--- a/src/Neptunium/ViewModel/SettingsPageViewModel.cs
+++ b/src/Neptunium/ViewModel/SettingsPageViewModel.cs
@@ -129,5 +129,11 @@ namespace Neptunium.ViewModel
             get { return (bool)NepApp.Settings.GetSetting(AppSettings.ShowRemoteMenu); }
             set { NepApp.Settings.SetSetting(AppSettings.ShowRemoteMenu, value); }
         }
+
+        public bool UseHapticFeedback
+        {
+            get { return (bool)NepApp.Settings.GetSetting(AppSettings.UseHapticFeedbackForNavigation); }
+            set { NepApp.Settings.SetSetting(AppSettings.UseHapticFeedbackForNavigation, value); }
+        }
     }
 }

--- a/src/Neptunium/ViewModel/SettingsPageViewModel.cs
+++ b/src/Neptunium/ViewModel/SettingsPageViewModel.cs
@@ -66,10 +66,16 @@ namespace Neptunium.ViewModel
             set { NepApp.Settings.SetSetting(AppSettings.TryToFindSongMetadata, value); }
         }
 
-        public bool SaySongNotifications
+        public bool SaySongNotificationsInBluetoothMode
         {
             get { return (bool)NepApp.Settings.GetSetting(AppSettings.SaySongNotificationsInBluetoothMode); }
             set { NepApp.Settings.SetSetting(AppSettings.SaySongNotificationsInBluetoothMode, value); }
+        }
+
+        public bool SaySongNotificationsWhenHeadphonesConnected
+        {
+            get { return (bool)NepApp.Settings.GetSetting(AppSettings.SaySongNotificationsWhenHeadphonesAreConnected); }
+            set { NepApp.Settings.SetSetting(AppSettings.SaySongNotificationsWhenHeadphonesAreConnected, value); }
         }
 
         public bool UpdateLockScreenWithSongArt

--- a/src/Neptunium/ViewModel/SettingsPageViewModel.cs
+++ b/src/Neptunium/ViewModel/SettingsPageViewModel.cs
@@ -123,5 +123,11 @@ namespace Neptunium.ViewModel
             get { return (bool)NepApp.Settings.GetSetting(AppSettings.AutomaticallyDetermineAppropriateBitrateBasedOnConnection); }
             set { NepApp.Settings.SetSetting(AppSettings.AutomaticallyDetermineAppropriateBitrateBasedOnConnection, value); }
         }
+
+        public bool ShowRemote
+        {
+            get { return (bool)NepApp.Settings.GetSetting(AppSettings.ShowRemoteMenu); }
+            set { NepApp.Settings.SetSetting(AppSettings.ShowRemoteMenu, value); }
+        }
     }
 }

--- a/src/Neptunium/ViewModel/StationProgramsPageViewModel.cs
+++ b/src/Neptunium/ViewModel/StationProgramsPageViewModel.cs
@@ -77,13 +77,38 @@ namespace Neptunium.ViewModel
             var collectionViewSource = new CollectionViewSource();
             collectionViewSource.Source = items
                 .OrderBy(x => x.TimeLocal.Hour)
-                .OrderBy(x => (int)x.TimeLocal.DayOfWeek)
-                .GroupBy(x => x.Day);
+                .GroupBy(x => x.Day)
+                .OrderBy(x => x.Key, new DayComparer());
             collectionViewSource.IsSourceGrouped = true;
             SortedScheduleItems = collectionViewSource;
 
             RaisePropertyChanged(nameof(ScheduleItems));
             RaisePropertyChanged(nameof(SortedScheduleItems));
+        }
+
+        private class DayComparer : IComparer<string>
+        {
+            private int GetDayNumber(string day)
+            {
+                switch(day.ToLower())
+                {
+                    case "sunday": return 0;
+                    case "monday": return 1;
+                    case "tuesday": return 2;
+                    case "wednesday": return 3;
+                    case "thursday": return 4;
+                    case "friday": return 5;
+                    case "saturday": return 6;
+                }
+
+                return 0;
+            }
+            public int Compare(string x, string y)
+            {
+                if (GetDayNumber(x) > GetDayNumber(y)) return 1;
+                else if (GetDayNumber(x) < GetDayNumber(y)) return -1;
+                else return 0;
+            }
         }
     }
 }

--- a/src/Neptunium/ViewModel/StationProgramsPageViewModel.cs
+++ b/src/Neptunium/ViewModel/StationProgramsPageViewModel.cs
@@ -75,7 +75,10 @@ namespace Neptunium.ViewModel
 
             ScheduleItems = new ObservableCollection<ScheduleItem>(items);
             var collectionViewSource = new CollectionViewSource();
-            collectionViewSource.Source = items. OrderBy(x => x.TimeLocal.Hour).GroupBy(x => x.Day);
+            collectionViewSource.Source = items
+                .OrderBy(x => x.TimeLocal.Hour)
+                .OrderBy(x => (int)x.TimeLocal.DayOfWeek)
+                .GroupBy(x => x.Day);
             collectionViewSource.IsSourceGrouped = true;
             SortedScheduleItems = collectionViewSource;
 

--- a/src/Neptunium/ViewModel/StationProgramsPageViewModel.cs
+++ b/src/Neptunium/ViewModel/StationProgramsPageViewModel.cs
@@ -7,48 +7,19 @@ using System.Threading.Tasks;
 using Crystal3.Navigation;
 using System.Collections.ObjectModel;
 using Neptunium.Model;
+using Windows.UI.Xaml.Data;
 
 namespace Neptunium.ViewModel
 {
     public class StationProgramsPageViewModel : UIViewModelBase
     {
-        public ObservableCollection<ScheduleItem> SundayItems
+        public CollectionViewSource SortedScheduleItems
         {
-            get { return GetPropertyValue<ObservableCollection<ScheduleItem>>(); }
-            private set { SetPropertyValue<ObservableCollection<ScheduleItem>>(value: value); }
+            get { return GetPropertyValue<CollectionViewSource>(); }
+            private set { SetPropertyValue<CollectionViewSource>(value: value); }
         }
 
-        public ObservableCollection<ScheduleItem> MondayItems
-        {
-            get { return GetPropertyValue<ObservableCollection<ScheduleItem>>(); }
-            private set { SetPropertyValue<ObservableCollection<ScheduleItem>>(value: value); }
-        }
-
-        public ObservableCollection<ScheduleItem> TuesdayItems
-        {
-            get { return GetPropertyValue<ObservableCollection<ScheduleItem>>(); }
-            private set { SetPropertyValue<ObservableCollection<ScheduleItem>>(value: value); }
-        }
-
-        public ObservableCollection<ScheduleItem> WednesdayItems
-        {
-            get { return GetPropertyValue<ObservableCollection<ScheduleItem>>(); }
-            private set { SetPropertyValue<ObservableCollection<ScheduleItem>>(value: value); }
-        }
-
-        public ObservableCollection<ScheduleItem> ThursdayItems
-        {
-            get { return GetPropertyValue<ObservableCollection<ScheduleItem>>(); }
-            private set { SetPropertyValue<ObservableCollection<ScheduleItem>>(value: value); }
-        }
-
-        public ObservableCollection<ScheduleItem> FridayItems
-        {
-            get { return GetPropertyValue<ObservableCollection<ScheduleItem>>(); }
-            private set { SetPropertyValue<ObservableCollection<ScheduleItem>>(value: value); }
-        }
-
-        public ObservableCollection<ScheduleItem> SaturdayItems
+        public ObservableCollection<ScheduleItem> ScheduleItems
         {
             get { return GetPropertyValue<ObservableCollection<ScheduleItem>>(); }
             private set { SetPropertyValue<ObservableCollection<ScheduleItem>>(value: value); }
@@ -78,14 +49,7 @@ namespace Neptunium.ViewModel
 
         private async Task LoadScheduleAsync()
         {
-            //theres a better way to do this.
-            SundayItems = new ObservableCollection<ScheduleItem>();
-            MondayItems = new ObservableCollection<ScheduleItem>();
-            TuesdayItems = new ObservableCollection<ScheduleItem>();
-            WednesdayItems = new ObservableCollection<ScheduleItem>();
-            ThursdayItems = new ObservableCollection<ScheduleItem>();
-            FridayItems = new ObservableCollection<ScheduleItem>();
-            SaturdayItems = new ObservableCollection<ScheduleItem>();
+            var items = new List<ScheduleItem>();
 
             var stations = await NepApp.Stations.GetStationsAsync();
 
@@ -104,49 +68,19 @@ namespace Neptunium.ViewModel
                         item.TimeLocal = listing.Time;
                         item.Program = program;
 
-                        switch (item.Day.ToLower())
-                        {
-                            case "sunday":
-                                SundayItems.Add(item);
-                                break;
-                            case "monday":
-                                MondayItems.Add(item);
-                                break;
-                            case "tuesday":
-                                TuesdayItems.Add(item);
-                                break;
-                            case "wednesday":
-                                WednesdayItems.Add(item);
-                                break;
-                            case "thursday":
-                                ThursdayItems.Add(item);
-                                break;
-                            case "friday":
-                                FridayItems.Add(item);
-                                break;
-                            case "saturday":
-                                SaturdayItems.Add(item);
-                                break;
-                        }
+                        items.Add(item);
                     }
                 }
             }
 
-            SundayItems = new ObservableCollection<ScheduleItem>(SundayItems.OrderBy(x => x.Time));
-            MondayItems = new ObservableCollection<ScheduleItem>(MondayItems.OrderBy(x => x.Time));
-            TuesdayItems = new ObservableCollection<ScheduleItem>(TuesdayItems.OrderBy(x => x.Time));
-            WednesdayItems = new ObservableCollection<ScheduleItem>(WednesdayItems.OrderBy(x => x.Time));
-            ThursdayItems = new ObservableCollection<ScheduleItem>(ThursdayItems.OrderBy(x => x.Time));
-            FridayItems = new ObservableCollection<ScheduleItem>(FridayItems.OrderBy(x => x.Time));
-            SaturdayItems = new ObservableCollection<ScheduleItem>(SaturdayItems.OrderBy(x => x.Time));
+            ScheduleItems = new ObservableCollection<ScheduleItem>(items);
+            var collectionViewSource = new CollectionViewSource();
+            collectionViewSource.Source = items. OrderBy(x => x.TimeLocal.Hour).GroupBy(x => x.Day);
+            collectionViewSource.IsSourceGrouped = true;
+            SortedScheduleItems = collectionViewSource;
 
-            RaisePropertyChanged(nameof(SundayItems));
-            RaisePropertyChanged(nameof(MondayItems));
-            RaisePropertyChanged(nameof(TuesdayItems));
-            RaisePropertyChanged(nameof(WednesdayItems));
-            RaisePropertyChanged(nameof(ThursdayItems));
-            RaisePropertyChanged(nameof(FridayItems));
-            RaisePropertyChanged(nameof(SaturdayItems));
+            RaisePropertyChanged(nameof(ScheduleItems));
+            RaisePropertyChanged(nameof(SortedScheduleItems));
         }
     }
 }

--- a/src/Neptunium/ViewModel/StationProgramsPageViewModel.cs
+++ b/src/Neptunium/ViewModel/StationProgramsPageViewModel.cs
@@ -28,7 +28,7 @@ namespace Neptunium.ViewModel
 
         protected override async void OnNavigatedTo(object sender, CrystalNavigationEventArgs e)
         {
-            if (e.Direction == CrystalNavigationDirection.Forward)
+            if (ScheduleItems == null)
             {
                 IsBusy = true;
 
@@ -45,6 +45,17 @@ namespace Neptunium.ViewModel
             }
 
             base.OnNavigatedTo(sender, e);
+        }
+
+        protected override void OnNavigatedFrom(object sender, CrystalNavigationEventArgs e)
+        {
+            if (SortedScheduleItems != null)
+                SortedScheduleItems.Source = null;
+
+            ScheduleItems?.Clear();
+            ScheduleItems = null;
+
+            base.OnNavigatedFrom(sender, e);
         }
 
         private async Task LoadScheduleAsync()
@@ -90,7 +101,7 @@ namespace Neptunium.ViewModel
         {
             private int GetDayNumber(string day)
             {
-                switch(day.ToLower())
+                switch (day.ToLower())
                 {
                     case "sunday": return 0;
                     case "monday": return 1;

--- a/src/Neptunium/ViewModel/StationsPageViewModel.cs
+++ b/src/Neptunium/ViewModel/StationsPageViewModel.cs
@@ -78,14 +78,17 @@ namespace Neptunium.ViewModel
             StationItem stationItem = (StationItem)station;
             if (NepApp.MediaPlayer.CurrentStreamer?.StationPlaying == stationItem) return; //don't show a dialog to play the current station
 
-            if ((await NepApp.UI.Overlay.ShowDialogFragmentAsync<StationInfoDialogFragment>(stationItem)).ResultType == Core.UI.NepAppUIManagerDialogResult.NepAppUIManagerDialogResultType.Positive)
+            var result = await NepApp.UI.Overlay.ShowDialogFragmentAsync<StationInfoDialogFragment>(stationItem);
+            if (result.ResultType == Core.UI.NepAppUIManagerDialogResult.NepAppUIManagerDialogResultType.Positive)
             {
                 var controller = await NepApp.UI.Overlay.ShowProgressDialogAsync(string.Format("Connecting to {0}...", stationItem.Name), "Please wait...");
                 controller.SetIndeterminate();
 
                 try
                 {
-                    await NepApp.MediaPlayer.TryStreamStationAsync(stationItem.Streams[0]);
+                    StationStream stream = result.Selection as StationStream;
+                    if (stream == null) stream = stationItem.Streams[0];
+                    await NepApp.MediaPlayer.TryStreamStationAsync(stream);
                     await controller.CloseAsync();
                 }
                 catch (Neptunium.Core.NeptuniumException ex)

--- a/src/Neptunium/ViewModel/StationsPageViewModel.cs
+++ b/src/Neptunium/ViewModel/StationsPageViewModel.cs
@@ -188,7 +188,7 @@ namespace Neptunium.ViewModel
                         }
                         else
                         {
-                            stream = stationItem.Streams.OrderByDescending(x => x.Bitrate).First(); ; //otherwise, grab a higher bitrate
+                            stream = stationItem.Streams.OrderByDescending(x => x.Bitrate).First(); //otherwise, grab a higher bitrate
                         }
                     }
 

--- a/src/Neptunium/ViewModel/StationsPageViewModel.cs
+++ b/src/Neptunium/ViewModel/StationsPageViewModel.cs
@@ -143,7 +143,20 @@ namespace Neptunium.ViewModel
                 try
                 {
                     StationStream stream = result.Selection as StationStream;
-                    if (stream == null) stream = stationItem.Streams[0];
+                    if (stream == null)
+                    {
+                        //check if we need to automatically choose a lower bitrate.
+                        if ((int)NepApp.Network.NetworkUtilizationBehavior < 2) //check if we're on "conservative" or "opt-in"
+                        {
+                            //grab the stream with the lowest bitrate
+                            stream = stationItem.Streams.OrderBy(x => x.Bitrate).First();
+                        }
+                        else
+                        {
+                            stream = stationItem.Streams.OrderByDescending(x => x.Bitrate).First(); ; //otherwise, grab a higher bitrate
+                        }
+                    }
+
                     await NepApp.MediaPlayer.TryStreamStationAsync(stream);
                     await controller.CloseAsync();
                 }

--- a/src/Neptunium/ViewModel/StationsPageViewModel.cs
+++ b/src/Neptunium/ViewModel/StationsPageViewModel.cs
@@ -25,22 +25,24 @@ namespace Neptunium.ViewModel
 
             DetectNetworkStatus();
 
+            LastPlayedStation = NepApp.Stations.LastPlayedStationName;
+            if (!string.IsNullOrWhiteSpace(LastPlayedStation))
+            {
+                IsBusy = true;
+                var station = await NepApp.Stations.GetStationByNameAsync(LastPlayedStation);
+                if (station != null)
+                {
+                    LastPlayedStationLogoUrl = station.StationLogoUrl;
+                    LastPlayedStationDescription = station.Description;
+                }
+
+                LastPlayedStationDate = NepApp.Stations.LastPlayedStationDate;
+                IsBusy = false;
+            }
+
             if (AvailableStations == null || AvailableStations?.Count == 0)
             {
                 IsBusy = true;
-
-                LastPlayedStation = NepApp.Stations.LastPlayedStationName;
-                if (!string.IsNullOrWhiteSpace(LastPlayedStation))
-                {
-                    var station = await NepApp.Stations.GetStationByNameAsync(LastPlayedStation);
-                    if (station != null)
-                    {
-                        LastPlayedStationLogoUrl = station.StationLogoUrl;
-                        LastPlayedStationDescription = station.Description;
-                    }
-
-                    LastPlayedStationDate = NepApp.Stations.LastPlayedStationDate;
-                }
 
                 AvailableStations = new ObservableCollection<StationItem>();
                 SortedAvailableStations = new AdvancedCollectionView(AvailableStations, false);
@@ -88,6 +90,9 @@ namespace Neptunium.ViewModel
         protected override void OnNavigatedFrom(object sender, CrystalNavigationEventArgs e)
         {
             NepApp.Network.IsConnectedChanged -= Network_IsConnectedChanged;
+
+            SortedAvailableStations.Clear();
+            AvailableStations.Clear();
 
             base.OnNavigatedFrom(sender, e);
         }

--- a/src/Neptunium/ViewModel/StationsPageViewModel.cs
+++ b/src/Neptunium/ViewModel/StationsPageViewModel.cs
@@ -10,6 +10,7 @@ using Neptunium.Core.Stations;
 using Crystal3.UI.Commands;
 using Neptunium.ViewModel.Dialog;
 using Windows.System;
+using Windows.UI.Popups;
 
 namespace Neptunium.ViewModel
 {
@@ -127,6 +128,15 @@ namespace Neptunium.ViewModel
             var result = await NepApp.UI.Overlay.ShowDialogFragmentAsync<StationInfoDialogFragment>(stationItem);
             if (result.ResultType == Core.UI.NepAppUIManagerDialogResult.NepAppUIManagerDialogResultType.Positive)
             {
+                if (NepApp.Network.NetworkUtilizationBehavior == NepAppNetworkManager.NetworkDeterminedAppBehaviorStyle.OptIn)
+                {
+                    if (await NepApp.UI.ShowYesNoDialogAsync("Data usage", "You're either over your data limit or roaming. Do you want to stream this station?") == false)
+                    {
+                        //user answered no
+                        return;
+                    }
+                }
+
                 var controller = await NepApp.UI.Overlay.ShowProgressDialogAsync(string.Format("Connecting to {0}...", stationItem.Name), "Please wait...");
                 controller.SetIndeterminate();
 

--- a/src/Neptunium/ViewModel/StationsPageViewModel.cs
+++ b/src/Neptunium/ViewModel/StationsPageViewModel.cs
@@ -20,27 +20,37 @@ namespace Neptunium.ViewModel
         {
             NepApp.Network.IsConnectedChanged += Network_IsConnectedChanged;
 
-            if (AvailableStations == null || AvailableStations?.Count == 0)
+            DetectNetworkStatus();
+            
+            try
             {
                 IsBusy = true;
-                AvailableStations = new ObservableCollection<StationItem>((await NepApp.Stations.GetStationsAsync())?.OrderBy(x => x.Name));
-                //GroupedStations = AvailableStations.GroupBy(x => x.Group ?? "Ungrouped Stations").OrderBy(x => x.Key).Select(x => x);
-
-                LastPlayedStation = NepApp.Stations.LastPlayedStationName;
-                if (!string.IsNullOrWhiteSpace(LastPlayedStation))
+            
+                if (AvailableStations == null || AvailableStations?.Count == 0)
                 {
-                    var station = await NepApp.Stations.GetStationByNameAsync(LastPlayedStation);
-                    if (station != null)
+                    AvailableStations = new ObservableCollection<StationItem>((await NepApp.Stations.GetStationsAsync())?.OrderBy(x => x.Name));
+                    //GroupedStations = AvailableStations.GroupBy(x => x.Group ?? "Ungrouped Stations").OrderBy(x => x.Key).Select(x => x);
+
+                    LastPlayedStation = NepApp.Stations.LastPlayedStationName;
+                    if (!string.IsNullOrWhiteSpace(LastPlayedStation))
                     {
-                        LastPlayedStationLogoUrl = station.StationLogoUrl;
-                        LastPlayedStationDescription = station.Description;
+                        var station = await NepApp.Stations.GetStationByNameAsync(LastPlayedStation);
+                        if (station != null)
+                        {
+                            LastPlayedStationLogoUrl = station.StationLogoUrl;
+                            LastPlayedStationDescription = station.Description;
+                        }
                     }
                 }
-
+            }
+            catch (Exception ex)
+            {
+                await NepApp.UI.ShowInfoDialogAsync("Uh-oh!", "An unexpected error occurred. " + ex.ToString());
+            }
+            finally
+            {
                 IsBusy = false;
             }
-
-            DetectNetworkStatus();
 
             base.OnNavigatedTo(sender, e);
         }

--- a/src/Neptunium/ViewModel/StationsPageViewModel.cs
+++ b/src/Neptunium/ViewModel/StationsPageViewModel.cs
@@ -76,6 +76,22 @@ namespace Neptunium.ViewModel
             private set { SetPropertyValue<string>(value: value); }
         }
 
+        public RelayCommand PlayLastPlayedStationCommand => new RelayCommand(async x =>
+        {
+            if (!string.IsNullOrWhiteSpace(LastPlayedStation))
+            {
+                var station = await NepApp.Stations.GetStationByNameAsync(LastPlayedStation);
+                if (station != null)
+                {
+                    ShowStationInfoCommand.Execute(station);
+
+                    LastPlayedStation = null;
+                    LastPlayedStationLogoUrl = null;
+                    LastPlayedStationDescription = null;
+                }
+            }
+        });
+
         public RelayCommand OpenStationWebsiteCommand => new RelayCommand(async station =>
         {
             StationItem stationItem = (StationItem)station;

--- a/src/Neptunium/ViewModel/StationsPageViewModel.cs
+++ b/src/Neptunium/ViewModel/StationsPageViewModel.cs
@@ -40,6 +40,8 @@ namespace Neptunium.ViewModel
                             LastPlayedStationLogoUrl = station.StationLogoUrl;
                             LastPlayedStationDescription = station.Description;
                         }
+
+                        LastPlayedStationDate = NepApp.Stations.LastPlayedStationDate;
                     }
                 }
             }
@@ -108,6 +110,12 @@ namespace Neptunium.ViewModel
         {
             get { return GetPropertyValue<string>(); }
             private set { SetPropertyValue<string>(value: value); }
+        }
+
+        public DateTime LastPlayedStationDate
+        {
+            get { return GetPropertyValue<DateTime>(); }
+            private set { SetPropertyValue<DateTime>(value: value); }
         }
 
         public Uri LastPlayedStationLogoUrl

--- a/src/Neptunium/ViewModel/StationsPageViewModel.cs
+++ b/src/Neptunium/ViewModel/StationsPageViewModel.cs
@@ -18,6 +18,8 @@ namespace Neptunium.ViewModel
     {
         protected override async void OnNavigatedTo(object sender, CrystalNavigationEventArgs e)
         {
+            NepApp.Network.IsConnectedChanged += Network_IsConnectedChanged;
+
             if (AvailableStations == null || AvailableStations?.Count == 0)
             {
                 IsBusy = true;
@@ -38,7 +40,40 @@ namespace Neptunium.ViewModel
                 IsBusy = false;
             }
 
+            DetectNetworkStatus();
+
             base.OnNavigatedTo(sender, e);
+        }
+
+        private void Network_IsConnectedChanged(object sender, EventArgs e)
+        {
+            App.Dispatcher.RunWhenIdleAsync(() =>
+            {
+                DetectNetworkStatus();
+            });
+        }
+
+        private void DetectNetworkStatus()
+        {
+            NetworkAvailable = NepApp.Network.IsConnected;
+
+            if (!NetworkAvailable)
+            {
+                NepApp.UI.Overlay.ShowSnackBarMessageAsync("Network disconnected.");
+            }
+        }
+
+        protected override void OnNavigatedFrom(object sender, CrystalNavigationEventArgs e)
+        {
+            NepApp.Network.IsConnectedChanged -= Network_IsConnectedChanged;
+
+            base.OnNavigatedFrom(sender, e);
+        }
+
+        public bool NetworkAvailable
+        {
+            get { return GetPropertyValue<bool>(); }
+            private set { SetPropertyValue<bool>(value: value); }
         }
 
         public ObservableCollection<StationItem> AvailableStations

--- a/src/Neptunium/ViewModel/StationsPageViewModel.cs
+++ b/src/Neptunium/ViewModel/StationsPageViewModel.cs
@@ -22,6 +22,18 @@ namespace Neptunium.ViewModel
                 IsBusy = true;
                 AvailableStations = new ObservableCollection<StationItem>((await NepApp.Stations.GetStationsAsync())?.OrderBy(x => x.Name));
                 //GroupedStations = AvailableStations.GroupBy(x => x.Group ?? "Ungrouped Stations").OrderBy(x => x.Key).Select(x => x);
+
+                LastPlayedStation = NepApp.Stations.LastPlayedStationName;
+                if (!string.IsNullOrWhiteSpace(LastPlayedStation))
+                {
+                    var station = await NepApp.Stations.GetStationByNameAsync(LastPlayedStation);
+                    if (station != null)
+                    {
+                        LastPlayedStationLogoUrl = station.StationLogoUrl;
+                        LastPlayedStationDescription = station.Description;
+                    }
+                }
+
                 IsBusy = false;
             }
 
@@ -44,6 +56,24 @@ namespace Neptunium.ViewModel
         {
             get { return GetPropertyValue<StationItem>(); }
             private set { SetPropertyValue<StationItem>(value: value); }
+        }
+
+        public string LastPlayedStation
+        {
+            get { return GetPropertyValue<string>(); }
+            private set { SetPropertyValue<string>(value: value); }
+        }
+
+        public Uri LastPlayedStationLogoUrl
+        {
+            get { return GetPropertyValue<Uri>(); }
+            private set { SetPropertyValue<Uri>(value: value); }
+        }
+
+        public string LastPlayedStationDescription
+        {
+            get { return GetPropertyValue<string>(); }
+            private set { SetPropertyValue<string>(value: value); }
         }
 
         public RelayCommand OpenStationWebsiteCommand => new RelayCommand(async station =>


### PR DESCRIPTION
Right. Continuing from v0.7 (#3), here are some changes I am going to be implemented for this version. This list is non-exhaustive.

## General
- [x] As of July 16th 2018, many stations are broken - They need to be updated
- [x] Work on decreasing battery usage (especially on Mobile). Cooperate with battery saver.
    - Disable album art fetching while Battery saver is on and app is in the background
- [x] Fix hamburger menu bugs on desktop
- [x] Integrate with Data Saver / work better on metered connections
    - Automatically choose lower bitrates on metered connections. Choose higher ones on better ones.
- [x] Don't scan for handoff opportunities on a cellular connection.
- Updated stations

### UI
- Bug fixes where appropriate

### IoT functionality (optional)
- [x] IoT shell which listens for commands over the network. (Tcp Listener?)
- [x] Mobile/Desktop can connect to IoT instances and act as a remote.

### Bugs created by this pull request
- [x] Fix a bug where the application will disable the stations list because it doesn't think their is an active connection on startup.
- [x] Fix a bug where the stations list will load indefinitely when starting the app in airplane mode.

### Delayed for future release
- Update for acrylic UI.
- If a song is found on MusicBrainz, pull its length and show a "song timer". **This kind of works**.
